### PR TITLE
Add linter/formatter files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+end_of_file = lf
+insert_final_newline = true
+
+[*.lua]
+indent_size = 2
+indent_style = space
+

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,3 @@
+read_globals = {
+	"vim",
+}


### PR DESCRIPTION
Added a .luacheckrc file to tell luacheck to set vim as a read-only global.

Added .editorconfig to codify code style choices.

This allows users to hook into existing formatters and linters using e.g. `nvim-conform`, `nvim-lint`.

I would like to contribute to this, I was working on a plugin myself, but you beat me to it ;). Could we agree on a code style using this as a starting point?