### PR TITLE
Log to file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Install Neovim
-      uses: rhymond/setup-neovim@v1
+      uses: rhysd/action-setup-vim@v1
       with:
-        neovim-version: ${{ matrix.neovim_version }}
+        neovim: true
     
     - name: Run tests
       run: make test

--- a/lua/eca/commands.lua
+++ b/lua/eca/commands.lua
@@ -1,7 +1,9 @@
 local Utils = require("eca.utils")
+local Logger = require("eca.logger")
 
 local M = {}
 
+--- Setup ECA commands
 function M.setup()
   -- Define ECA commands
   vim.api.nvim_create_user_command("EcaChat", function(opts)
@@ -43,7 +45,7 @@ function M.setup()
 
   vim.api.nvim_create_user_command("EcaAddSelection", function()
     -- Force exit visual mode and set marks
-    vim.cmd('normal! \\<Esc>')
+    vim.cmd("normal! \\<Esc>")
     vim.defer_fn(function()
       require("eca.api").add_selection_context()
     end, 50) -- Small delay to ensure marks are set
@@ -68,7 +70,7 @@ function M.setup()
     if opts.args and opts.args ~= "" then
       require("eca.api").remove_context(opts.args)
     else
-      Utils.warn("Please provide a file path to remove")
+      Logger.notify("Please provide a file path to remove", vim.log.levels.WARN)
     end
   end, {
     desc = "Remove specific context from ECA",
@@ -83,7 +85,7 @@ function M.setup()
   })
 
   -- ===== Selected Code Commands =====
-  
+
   vim.api.nvim_create_user_command("EcaShowSelection", function()
     require("eca.api").show_selected_code()
   end, {
@@ -97,12 +99,12 @@ function M.setup()
   })
 
   -- ===== TODOs Commands =====
-  
+
   vim.api.nvim_create_user_command("EcaAddTodo", function(opts)
     if opts.args and opts.args ~= "" then
       require("eca.api").add_todo(opts.args)
     else
-      Utils.warn("Please provide TODO content")
+      Logger.notify("Please provide TODO content", vim.log.levels.WARN)
     end
   end, {
     desc = "Add a new TODO to ECA",
@@ -121,10 +123,10 @@ function M.setup()
       if index then
         require("eca.api").toggle_todo(index)
       else
-        Utils.warn("Please provide a valid TODO index")
+        Logger.notify("Please provide a valid TODO index", vim.log.levels.WARN)
       end
     else
-      Utils.warn("Please provide TODO index to toggle")
+      Logger.notify("Please provide TODO index to toggle", vim.log.levels.WARN)
     end
   end, {
     desc = "Toggle TODO completion status",
@@ -159,7 +161,7 @@ function M.setup()
     local eca = require("eca")
     local status = eca.server and eca.server:status() or "Not initialized"
     local status_icon = "○"
-    
+
     if status == "Running" then
       status_icon = "✓"
     elseif status == "Starting" then
@@ -167,33 +169,66 @@ function M.setup()
     elseif status == "Failed" then
       status_icon = "✗"
     end
-    
-    Utils.info("ECA Server Status: " .. status .. " " .. status_icon)
-    
+
+    Logger.notify("ECA Server Status: " .. status .. " " .. status_icon, vim.log.levels.INFO)
+
     -- Also show path info if available
     if eca.server and eca.server._path_finder then
       local config = require("eca.config")
       if config.server_path and config.server_path ~= "" then
-        Utils.info("Server path: " .. config.server_path .. " (custom)")
+        Logger.notify("Server path: " .. config.server_path .. " (custom)", vim.log.levels.INFO)
       else
-        Utils.info("Server path: auto-detected/downloaded")
+        Logger.notify("Server path: auto-detected/downloaded", vim.log.levels.INFO)
       end
     end
   end, {
     desc = "Show ECA server status with details",
   })
 
-  vim.api.nvim_create_user_command("EcaLogs", function()
-    require("eca.api").show_logs()
+  vim.api.nvim_create_user_command("EcaLogs", function(opts)
+    local Api = require("eca.api")
+    local subcommand = opts.args and opts.args:match("%S+") or "show"
+
+    if subcommand == "show" then
+      Api.show_logs()
+    elseif subcommand == "log_path" then
+      local log_path = Logger.get_log_path()
+      Logger.notify("ECA log file: " .. log_path, vim.log.levels.INFO)
+    elseif subcommand == "clear" then
+      if Logger.clear_log() then
+        Logger.notify("ECA log file cleared", vim.log.levels.INFO)
+      else
+        Logger.notify("Failed to clear log file", vim.log.levels.WARN)
+      end
+    elseif subcommand == "stats" then
+      local stats = Logger.get_log_stats()
+      if stats then
+        Logger.notify(string.format("Log file: %s", stats.path), vim.log.levels.INFO)
+        Logger.notify(string.format("Size: %.2fMB (%d bytes)", stats.size_mb, stats.size), vim.log.levels.INFO)
+        Logger.notify(string.format("Last modified: %s", stats.modified), vim.log.levels.INFO)
+      else
+        Logger.notify("No log file stats available", vim.log.levels.INFO)
+      end
+    else
+      Logger.notify("Unknown EcaLogs subcommand: " .. subcommand, vim.log.levels.WARN)
+      Logger.notify("Available subcommands: show, log_path, clear, stats", vim.log.levels.INFO)
+    end
   end, {
-    desc = "Open ECA server logs in a new buffer",
+    desc = "ECA logging commands (show, log_path, clear, stats)",
+    nargs = "?",
+    complete = function(ArgLead, CmdLine, CursorPos)
+      local subcommands = { "show", "log_path", "clear", "stats" }
+      return vim.tbl_filter(function(cmd)
+        return cmd:match("^" .. ArgLead)
+      end, subcommands)
+    end,
   })
 
   vim.api.nvim_create_user_command("EcaSend", function(opts)
     if opts.args and opts.args ~= "" then
       require("eca.api").send_message(opts.args)
     else
-      Utils.warn("Please provide a message to send")
+      Logger.notify("Please provide a message to send", vim.log.levels.WARN)
     end
   end, {
     desc = "Send a message to ECA",
@@ -205,7 +240,10 @@ function M.setup()
     local width = Config.get_window_width()
     local columns = vim.o.columns
     local percentage = Config.options.windows.width
-    Utils.info(string.format("Width: %d columns (%.1f%% of %d total columns)", width, percentage, columns))
+    Logger.notify(
+      string.format("Width: %d columns (%.1f%% of %d total columns)", width, percentage, columns),
+      vim.log.levels.INFO
+    )
   end, {
     desc = "Debug window width calculation",
   })
@@ -213,23 +251,23 @@ function M.setup()
   vim.api.nvim_create_user_command("EcaRedownload", function()
     local eca = require("eca")
     local Utils = require("eca.utils")
-    
+
     if eca.server and eca.server:is_running() then
-      Utils.info("Stopping server before re-download...")
+      Logger.notify("Stopping server before re-download...", vim.log.levels.INFO)
       eca.server:stop()
     end
-    
+
     -- Remove existing version file to force re-download
     local cache_dir = Utils.get_cache_dir()
     local version_file = cache_dir .. "/eca-version"
     os.remove(version_file)
-    
+
     -- Remove existing binary
     local server_binary = cache_dir .. "/eca"
     os.remove(server_binary)
-    
-    Utils.info("Removed cached ECA server. Will re-download on next start.")
-    
+
+    Logger.notify("Removed cached ECA server. Will re-download on next start.", vim.log.levels.INFO)
+
     -- Restart server
     vim.defer_fn(function()
       if eca.server then
@@ -243,13 +281,13 @@ function M.setup()
   vim.api.nvim_create_user_command("EcaStopResponse", function()
     local eca = require("eca")
     local Utils = require("eca.utils")
-    
+
     -- Force stop any ongoing streaming response
     if eca.sidebar then
       eca.sidebar:_finalize_streaming_response()
-      Utils.info("Forced stop of streaming response")
+      Logger.notify("Forced stop of streaming response", vim.log.levels.INFO)
     else
-      Utils.warn("No active sidebar to stop")
+      Logger.notify("No active sidebar to stop", vim.log.levels.WARN)
     end
   end, {
     desc = "Emergency stop for infinite loops or runaway responses",
@@ -257,7 +295,7 @@ function M.setup()
 
   vim.api.nvim_create_user_command("EcaFixTreesitter", function()
     local Utils = require("eca.utils")
-    
+
     -- Emergency treesitter fix for chat buffer
     vim.schedule(function()
       local eca = require("eca")
@@ -266,7 +304,7 @@ function M.setup()
         if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
           -- Disable all highlighting for this buffer
           pcall(vim.api.nvim_set_option_value, "syntax", "off", { buf = bufnr })
-          
+
           -- Destroy treesitter highlighter if it exists
           pcall(function()
             if vim.treesitter.highlighter.active[bufnr] then
@@ -274,21 +312,21 @@ function M.setup()
               vim.treesitter.highlighter.active[bufnr] = nil
             end
           end)
-          
-          Utils.info("Disabled treesitter highlighting for ECA chat buffer")
-          Utils.info("Buffer " .. bufnr .. " highlighting disabled")
+
+          Logger.notify("Disabled treesitter highlighting for ECA chat buffer", vim.log.levels.INFO)
+          Logger.notify("Buffer " .. bufnr .. " highlighting disabled", vim.log.levels.INFO)
         else
-          Utils.warn("No valid chat buffer found")
+          Logger.notify("No valid chat buffer found", vim.log.levels.WARN)
         end
       else
-        Utils.warn("No active ECA sidebar found")
+        Logger.notify("No active ECA sidebar found", vim.log.levels.WARN)
       end
     end)
   end, {
     desc = "Emergency fix for treesitter issues in ECA chat",
   })
 
-  Utils.debug("ECA commands registered")
+  Logger.debug("ECA commands registered")
 end
 
 return M

--- a/lua/eca/config.lua
+++ b/lua/eca/config.lua
@@ -3,13 +3,23 @@ local M = {}
 
 ---@class eca.Config
 M._defaults = {
-  debug = false,
   ---@type string
   server_path = "", -- Path to the ECA binary, will download automatically if empty
   ---@type string
   server_args = "", -- Extra args for the eca start command
   ---@type string
   usage_string_format = "{messageCost} / {sessionCost}",
+  ---@class eca.LogConfig
+  ---@field display 'popup'|'split'
+  ---@field level integer
+  ---@field file string
+  ---@field max_file_size_mb number
+  log = {
+    display = "split",
+    level = vim.log.levels.INFO,
+    file = "",
+    max_file_size_mb = 10, -- Maximum log file size in MB before warning
+  },
   behaviour = {
     auto_set_keymaps = true,
     auto_focus_sidebar = true,

--- a/lua/eca/logger.lua
+++ b/lua/eca/logger.lua
@@ -1,0 +1,194 @@
+local uv = vim.uv or vim.loop
+
+---@class eca.Logger
+local M = {}
+
+---@type eca.LogConfig
+M.config = nil
+
+local LEVEL_NAMES = {
+  [vim.log.levels.TRACE] = "TRACE",
+  [vim.log.levels.DEBUG] = "DEBUG",
+  [vim.log.levels.INFO] = "INFO",
+  [vim.log.levels.WARN] = "WARN",
+  [vim.log.levels.ERROR] = "ERROR",
+}
+
+---Get XDG-compliant default log path
+---@return string
+local function get_default_log_path()
+  return vim.fn.stdpath("state") .. "/eca.log"
+end
+
+---@type eca.LogConfig
+local DEFAULT_CONFIG = {
+  level = vim.log.levels.INFO,
+  file = get_default_log_path(),
+  display = "split",
+  max_file_size_mb = 10,
+}
+
+---Get log level name
+---@param level integer
+---@return string
+local function get_level_name(level)
+  return LEVEL_NAMES[level] or "UNKNOWN"
+end
+
+---Check if log file is over size limit and notify if needed
+---@param log_path string
+---@param max_size_mb number
+local function check_log_size_and_notify(log_path, max_size_mb)
+  uv.fs_stat(log_path, function(err, stat)
+    if err or not stat then
+      return
+    end
+
+    local max_size = max_size_mb * 1024 * 1024 -- Convert MB to bytes
+    if stat.size > max_size then
+      local size_mb = math.floor(stat.size / 1024 / 1024 * 100) / 100
+      vim.notify(
+        string.format("ECA log file is large (%.1fMB). Consider clearing it with :EcaLogs clear", size_mb),
+        vim.log.levels.WARN,
+        { title = "ECA" }
+      )
+    end
+  end)
+end
+
+--- Initialize logger with configuration
+---@param config eca.LogConfig
+function M.setup(config)
+  config = config or {}
+  local strings = require("eca.strings")
+
+  M.config = {
+    level = config.level or DEFAULT_CONFIG.level,
+    file = strings.is_nil_or_empty(config.file) and DEFAULT_CONFIG.file or config.file,
+    display = config.display or DEFAULT_CONFIG.display,
+    max_file_size_mb = config.max_file_size_mb or DEFAULT_CONFIG.max_file_size_mb,
+  }
+
+  local log_path = M.get_log_path()
+  check_log_size_and_notify(log_path, M.config.max_file_size_mb)
+end
+
+---@return string
+function M.get_display()
+  return M.config and M.config.display or "split"
+end
+
+--- Get current log file path
+---@return string
+function M.get_log_path()
+  assert(M.config and M.config.file ~= "", "Logger must be configured with a non-empty file path")
+  return vim.fn.expand(M.config.file)
+end
+
+--- Log a message to the log file
+---@param message string
+---@param level integer
+---@param opts? {title?: string}
+function M.log(message, level, opts)
+  opts = opts or {}
+
+  if not M.config then
+    return
+  end
+
+  if level < M.config.level then
+    return
+  end
+
+  local log_path = M.get_log_path()
+  vim.fn.mkdir(vim.fn.fnamemodify(log_path, ":h"), "p")
+
+  local timestamp = os.date("%Y-%m-%d %H:%M:%S")
+  local level_name = get_level_name(level)
+  local prefix = opts.title == "SERVER" and "SERVER" or "CLIENT"
+  local formatted = string.format("[%s] %-5s [%s] %s\n", timestamp, level_name, prefix, message)
+
+  uv.fs_open(log_path, "a", 420, function(err, fd)
+    if err or not fd then
+      return
+    end
+    uv.fs_write(fd, formatted, -1, function()
+      uv.fs_close(fd)
+    end)
+  end)
+end
+
+--- Log debug message
+---@param message string
+---@param opts? {title?: string}
+function M.debug(message, opts)
+  M.log(message, vim.log.levels.DEBUG, opts)
+end
+
+--- Log info message
+---@param message string
+---@param opts? {title?: string}
+function M.info(message, opts)
+  M.log(message, vim.log.levels.INFO, opts)
+end
+
+--- Log warn message
+---@param message string
+---@param opts? {title?: string}
+function M.warn(message, opts)
+  M.log(message, vim.log.levels.WARN, opts)
+end
+
+--- Log error message
+---@param message string
+---@param opts? {title?: string}
+function M.error(message, opts)
+  M.log(message, vim.log.levels.ERROR, opts)
+end
+
+--- Send notification to user via vim.notify
+---@param message string
+---@param level? integer vim.log.levels (default: INFO)
+---@param opts? {title?: string, once?: boolean}
+function M.notify(message, level, opts)
+  level = level or vim.log.levels.INFO
+  opts = opts or {}
+
+  M.log(message, level, opts)
+
+  vim.notify(message, level, {
+    title = opts.title or "ECA",
+    once = opts.once,
+  })
+end
+
+--- Get log file statistics
+---@return table|nil
+function M.get_log_stats()
+  local log_path = M.get_log_path()
+  local stat = uv.fs_stat(log_path)
+  if not stat then
+    return nil
+  end
+
+  return {
+    path = log_path,
+    size = stat.size,
+    size_mb = math.floor(stat.size / 1024 / 1024 * 100) / 100,
+    modified = os.date("%Y-%m-%d %H:%M:%S", stat.mtime.sec),
+  }
+end
+
+--- Clear log file
+---@return boolean
+function M.clear_log()
+  local log_path = M.get_log_path()
+  local file = io.open(log_path, "w")
+  if file then
+    file:close()
+    return true
+  end
+  return false
+end
+
+return M

--- a/lua/eca/nui_sidebar.lua
+++ b/lua/eca/nui_sidebar.lua
@@ -1,4 +1,5 @@
 local Utils = require("eca.utils")
+local Logger = require("eca.logger")
 local Config = require("eca.config")
 
 -- Check if nui.nvim is available
@@ -6,12 +7,12 @@ local nui_available, Split = pcall(require, "nui.split")
 local nui_event_available, event = pcall(require, "nui.utils.autocmd")
 
 if not nui_available then
-  Utils.warn("nui.nvim not found. Install MunifTanjim/nui.nvim for enhanced UI experience.")
+  Logger.notify("nui.nvim not found. Install MunifTanjim/nui.nvim for enhanced UI experience.", vim.log.levels.WARN)
   return nil
 end
 
 if not nui_event_available then
-  Utils.warn("nui.utils.autocmd not found. Some features may not work properly.")
+  Logger.notify("nui.utils.autocmd not found. Some features may not work properly.", vim.log.levels.WARN)
   event = nil
 end
 
@@ -80,10 +81,10 @@ function M:open(opts)
   
   -- Setup containers if not initialized or if we need to refresh content
   if not self._initialized then
-    Utils.debug("Setting up nui containers (first time)")
+    Logger.debug("Setting up nui containers (first time)")
     self:_setup_containers()
   else
-    Utils.debug("Reusing existing nui containers")
+    Logger.debug("Reusing existing nui containers")
     self:_refresh_container_content()
   end
   
@@ -91,7 +92,7 @@ function M:open(opts)
     vim.api.nvim_set_current_win(self.containers.input.winid)
   end
   
-  Utils.debug("ECA nui sidebar opened")
+  Logger.debug("ECA nui sidebar opened")
 end
 
 function M:close()
@@ -106,7 +107,7 @@ function M:_close_windows_only()
       container.winid = nil
     end
   end
-  Utils.debug("ECA nui sidebar windows closed")
+  Logger.debug("ECA nui sidebar windows closed")
 end
 
 function M:_close_and_cleanup()
@@ -125,7 +126,7 @@ function M:_close_and_cleanup()
     end
   end
   self.containers = {}
-  Utils.debug("ECA nui sidebar closed and cleaned up")
+  Logger.debug("ECA nui sidebar closed and cleaned up")
 end
 
 ---@param opts? table
@@ -181,7 +182,7 @@ end
 function M:new_chat()
   self:reset()
   self._force_welcome = true
-  Utils.debug("New chat initiated - will show welcome content on next open")
+  Logger.debug("New chat initiated - will show welcome content on next open")
 end
 
 ---@private
@@ -246,7 +247,7 @@ function M:_create_nui_containers()
   })
   self.containers.chat:mount()
   self:_setup_container_events(self.containers.chat, "chat")
-  Utils.debug("Mounted nui container: chat (winid: " .. self.containers.chat.winid .. ")")
+  Logger.debug("Mounted nui container: chat (winid: " .. self.containers.chat.winid .. ")")
   
   -- Track the last mounted container winid for relative positioning
   local last_winid = self.containers.chat.winid
@@ -271,7 +272,7 @@ function M:_create_nui_containers()
     self.containers.selected_code:mount()
     self:_setup_container_events(self.containers.selected_code, "selected_code")
     last_winid = self.containers.selected_code.winid
-    Utils.debug("Mounted nui container: selected_code (winid: " .. last_winid .. ")")
+    Logger.debug("Mounted nui container: selected_code (winid: " .. last_winid .. ")")
   end
   
   -- 3. Create todos container (conditional)
@@ -293,7 +294,7 @@ function M:_create_nui_containers()
     self.containers.todos:mount()
     self:_setup_container_events(self.containers.todos, "todos")
     last_winid = self.containers.todos.winid
-    Utils.debug("Mounted nui container: todos (winid: " .. last_winid .. ")")
+    Logger.debug("Mounted nui container: todos (winid: " .. last_winid .. ")")
   end
   
   -- 4. Create contexts container (always present)
@@ -314,7 +315,7 @@ function M:_create_nui_containers()
   self.containers.contexts:mount()
   self:_setup_container_events(self.containers.contexts, "contexts")
   last_winid = self.containers.contexts.winid
-  Utils.debug("Mounted nui container: contexts (winid: " .. last_winid .. ")")
+  Logger.debug("Mounted nui container: contexts (winid: " .. last_winid .. ")")
   
   -- 5. Create usage container (always present)
   self.containers.usage = Split({
@@ -335,7 +336,7 @@ function M:_create_nui_containers()
   self.containers.usage:mount()
   self:_setup_container_events(self.containers.usage, "usage")
   last_winid = self.containers.usage.winid
-  Utils.debug("Mounted nui container: usage (winid: " .. last_winid .. ")")
+  Logger.debug("Mounted nui container: usage (winid: " .. last_winid .. ")")
   
   -- 6. Create input container (always present)
   self.containers.input = Split({
@@ -354,9 +355,9 @@ function M:_create_nui_containers()
   })
   self.containers.input:mount()
   self:_setup_container_events(self.containers.input, "input")
-  Utils.debug("Mounted nui container: input (winid: " .. self.containers.input.winid .. ")")
+  Logger.debug("Mounted nui container: input (winid: " .. self.containers.input.winid .. ")")
   
-  Utils.debug(string.format("Created nui containers: chat=%d, selected_code=%s, todos=%s, contexts=%d, usage=%d, input=%d", 
+  Logger.debug(string.format("Created nui containers: chat=%d, selected_code=%s, todos=%s, contexts=%d, usage=%d, input=%d", 
     chat_height, 
     selected_code_height > 0 and tostring(selected_code_height) or "hidden",
     todos_height > 0 and tostring(todos_height) or "hidden",
@@ -373,17 +374,17 @@ function M:_setup_container_events(container, name)
   
   -- Setup event handling for each container
   container:on(event.event.BufWinEnter, function()
-    Utils.debug("Container " .. name .. " entered")
+    Logger.debug("Container " .. name .. " entered")
     -- Container-specific setup can go here
   end)
   
   container:on(event.event.BufLeave, function()
-    Utils.debug("Container " .. name .. " left")
+    Logger.debug("Container " .. name .. " left")
     -- Container-specific cleanup can go here
   end)
   
   container:on(event.event.WinClosed, function()
-    Utils.debug("Container " .. name .. " window closed")
+    Logger.debug("Container " .. name .. " window closed")
     self:_handle_container_closed(name)
   end)
   
@@ -529,7 +530,7 @@ function M:add_context(context)
       -- Update existing context
       self._contexts[i] = context
       self:_update_contexts_display()
-      Utils.info("Updated context: " .. context.path)
+      Logger.info("Updated context: " .. context.path)
       return
     end
   end
@@ -537,7 +538,7 @@ function M:add_context(context)
   -- Add new context
   table.insert(self._contexts, context)
   self:_update_contexts_display()
-  Utils.info("Added context: " .. context.path .. " (" .. #self._contexts .. " total)")
+  Logger.info("Added context: " .. context.path .. " (" .. #self._contexts .. " total)")
 end
 
 ---@param path string Path to remove from contexts
@@ -546,11 +547,11 @@ function M:remove_context(path)
     if context.path == path then
       table.remove(self._contexts, i)
       self:_update_contexts_display()
-      Utils.info("Removed context: " .. path)
+      Logger.info("Removed context: " .. path)
       return true
     end
   end
-  Utils.warn("Context not found: " .. path)
+  Logger.warn("Context not found: " .. path)
   return false
 end
 
@@ -568,40 +569,40 @@ function M:clear_contexts()
   local count = #self._contexts
   self._contexts = {}
   self:_update_contexts_display()
-  Utils.info("Cleared " .. count .. " contexts")
+  Logger.info("Cleared " .. count .. " contexts")
 end
 
 ---@param code table Selected code object with filepath, content, start_line, end_line
 function M:set_selected_code(code)
   self._selected_code = code
   self:_update_selected_code_display()
-  Utils.info("Selected code updated: " .. (code and code.filepath or "none"))
+  Logger.info("Selected code updated: " .. (code and code.filepath or "none"))
 end
 
 function M:clear_selected_code()
   self._selected_code = nil
   self:_update_selected_code_display()
-  Utils.info("Selected code cleared")
+  Logger.info("Selected code cleared")
 end
 
 ---@param todo table Todo object with content, status ("pending", "completed")
 function M:add_todo(todo)
   table.insert(self._todos, todo)
   self:_update_todos_display()
-  Utils.info("Added TODO: " .. todo.content)
+  Logger.info("Added TODO: " .. todo.content)
 end
 
 ---@param index integer Index of todo to toggle
 function M:toggle_todo(index)
   if index <= 0 or index > #self._todos then
-    Utils.warn("Invalid TODO index: " .. index)
+    Logger.warn("Invalid TODO index: " .. index)
     return false
   end
   
   local todo = self._todos[index]
   todo.status = todo.status == "completed" and "pending" or "completed"
   self:_update_todos_display()
-  Utils.info("Toggled TODO " .. index .. ": " .. todo.content)
+  Logger.info("Toggled TODO " .. index .. ": " .. todo.content)
   return true
 end
 
@@ -609,7 +610,7 @@ function M:clear_todos()
   local count = #self._todos
   self._todos = {}
   self:_update_todos_display()
-  Utils.info("Cleared " .. count .. " TODOs")
+  Logger.info("Cleared " .. count .. " TODOs")
 end
 
 ---@return table List of active todos
@@ -764,12 +765,12 @@ function M:_set_welcome_content()
     
     -- Only set welcome content if buffer is empty or has no meaningful content
     if has_content then
-      Utils.debug("Preserving existing chat content")
+      Logger.debug("Preserving existing chat content")
       return
     end
   else
     -- Force welcome content and reset the flag
-    Utils.debug("Forcing welcome content for new chat")
+    Logger.debug("Forcing welcome content for new chat")
     self._force_welcome = false
   end
   
@@ -793,7 +794,7 @@ function M:_set_welcome_content()
     "",
   }
   
-  Utils.debug("Setting welcome content for new chat")
+  Logger.debug("Setting welcome content for new chat")
   vim.api.nvim_buf_set_lines(chat.bufnr, 0, -1, false, lines)
   
   -- Auto-add repoMap context if enabled and not already present
@@ -813,7 +814,7 @@ function M:_set_welcome_content()
         path = "repoMap",
         content = "Repository structure and code mapping for better project understanding"
       })
-      Utils.debug("Auto-added repoMap context on welcome")
+      Logger.debug("Auto-added repoMap context on welcome")
     end
   end
 end
@@ -1030,7 +1031,7 @@ end
 
 ---@param message string
 function M:_send_message(message)
-  Utils.debug("Sending message: " .. message)
+  Logger.debug("Sending message: " .. message)
   
   -- Store the last user message to avoid duplication
   self._last_user_message = message
@@ -1043,10 +1044,10 @@ function M:_send_message(message)
   if eca.server and eca.server:is_running() then
     -- Include active contexts in the message
     local contexts = self:get_contexts()
-    Utils.debug("Sending message with " .. #contexts .. " contexts")
+    Logger.debug("Sending message with " .. #contexts .. " contexts")
     eca.server:send_chat_message(message, contexts, function(err, result)
       if err then
-        Utils.error("Failed to send message to ECA server: " .. tostring(err))
+        Logger.error("Failed to send message to ECA server: " .. tostring(err))
         self:_add_message("assistant", "❌ **Error**: Failed to send message to ECA server")
       end
       -- Response will come through server notification handler
@@ -1127,7 +1128,7 @@ function M:_handle_streaming_text(text)
       
       -- If the accumulated text so far exactly matches the user message, skip it
       if trimmed_text == trimmed_user_msg then
-        Utils.debug("Skipping echo of user message: " .. trimmed_text)
+        Logger.debug("Skipping echo of user message: " .. trimmed_text)
         return
       end
     end

--- a/lua/eca/path_finder.lua
+++ b/lua/eca/path_finder.lua
@@ -1,6 +1,7 @@
 local uv = vim.uv or vim.loop
 local Utils = require("eca.utils")
 local Config = require("eca.config")
+local Logger = require("eca.logger")
 
 ---@class eca.PathFinder
 ---@field private _cache_dir string
@@ -30,7 +31,7 @@ function M:_get_artifacts()
     },
     windows = {
       x86_64 = "eca-native-windows-amd64.zip",
-    }
+    },
   }
 end
 
@@ -49,14 +50,14 @@ function M:_get_artifact_name(platform, arch)
   elseif platform:match("windows") or platform:match("mingw") or platform:match("msys") then
     platform = "windows"
   end
-  
+
   local artifacts = self:_get_artifacts()
   local platform_artifacts = artifacts[platform]
-  
+
   if not platform_artifacts then
     error("Unsupported platform: " .. platform)
   end
-  
+
   return platform_artifacts[arch] or "eca.jar"
 end
 
@@ -83,7 +84,7 @@ function M:_read_version_file()
   if not file then
     return nil
   end
-  
+
   local version = file:read("*a"):gsub("%s+", "")
   file:close()
   return version ~= "" and version or nil
@@ -93,33 +94,33 @@ end
 function M:_write_version_file(version)
   -- Ensure cache directory exists
   vim.fn.mkdir(self._cache_dir, "p")
-  
+
   local file = io.open(self._version_file, "w")
   if file then
     file:write(version)
     file:close()
   else
-    Utils.warn("Could not write version file: " .. self._version_file)
+    Logger.notify("Could not write version file: " .. self._version_file, vim.log.levels.WARN)
   end
 end
 
 ---@return string?
 function M:_get_latest_version()
-  local cmd = 'curl -s https://api.github.com/repos/editor-code-assistant/eca/releases/latest'
-  local handle = io.popen(cmd .. ' 2>/dev/null')
-  
+  local cmd = "curl -s https://api.github.com/repos/editor-code-assistant/eca/releases/latest"
+  local handle = io.popen(cmd .. " 2>/dev/null")
+
   if not handle then
-    Utils.warn("Failed to check for latest ECA version")
+    Logger.notify("Failed to check for latest ECA version", vim.log.levels.WARN)
     return nil
   end
-  
+
   local response = handle:read("*a")
   handle:close()
-  
+
   if not response or response == "" then
     return nil
   end
-  
+
   -- Parse JSON to get tag_name
   local tag_match = response:match('"tag_name"%s*:%s*"([^"]+)"')
   return tag_match
@@ -130,64 +131,58 @@ end
 ---@return boolean success
 function M:_download_latest_server(server_path, version)
   local artifact_name = self:_get_artifact_name()
-  local download_url = string.format(
-    "https://github.com/editor-code-assistant/eca/releases/download/%s/%s",
-    version,
-    artifact_name
-  )
-  
+  local download_url =
+    string.format("https://github.com/editor-code-assistant/eca/releases/download/%s/%s", version, artifact_name)
+
   local download_path = self._cache_dir .. "/" .. artifact_name
-  
-  Utils.info("Downloading latest ECA server version from: " .. download_url)
-  
+
+  Logger.notify("Downloading latest ECA server version from: " .. download_url, vim.log.levels.INFO)
+
   -- Ensure cache directory exists
   vim.fn.mkdir(self._cache_dir, "p")
-  
+
   -- Download the file
   local download_cmd = string.format(
     "curl -L --fail --show-error --silent -o %s %s",
     vim.fn.shellescape(download_path),
     vim.fn.shellescape(download_url)
   )
-  
+
   local download_result = os.execute(download_cmd)
   if download_result ~= 0 then
-    Utils.error("Failed to download ECA server from: " .. download_url)
+    Logger.notify("Failed to download ECA server from: " .. download_url, vim.log.levels.ERROR)
     return false
   end
-  
+
   -- Extract if it's a zip file
   if artifact_name:match("%.zip$") then
-    local extract_cmd = string.format(
-      "cd %s && unzip -o %s",
-      vim.fn.shellescape(self._cache_dir),
-      vim.fn.shellescape(artifact_name)
-    )
-    
+    local extract_cmd =
+      string.format("cd %s && unzip -o %s", vim.fn.shellescape(self._cache_dir), vim.fn.shellescape(artifact_name))
+
     local extract_result = os.execute(extract_cmd)
     if extract_result ~= 0 then
-      Utils.error("Failed to extract ECA server")
+      Logger.notify("Failed to extract ECA server", vim.log.levels.ERROR)
       return false
     end
-    
+
     -- Remove the zip file after extraction
     os.remove(download_path)
   end
-  
+
   -- Make executable (if not Windows)
   if not vim.loop.os_uname().sysname:lower():match("windows") then
     os.execute("chmod +x " .. vim.fn.shellescape(server_path))
   end
-  
+
   if not Utils.file_exists(server_path) then
-    Utils.error("ECA server binary not found after download and extraction")
+    Logger.notify("ECA server binary not found after download and extraction", vim.log.levels.ERROR)
     return false
   end
-  
+
   -- Write version file
   self:_write_version_file(version)
-  
-  Utils.info("ECA server downloaded successfully")
+
+  Logger.notify("ECA server downloaded successfully", vim.log.levels.INFO)
   return true
 end
 
@@ -197,38 +192,40 @@ function M:find()
   local custom_path = Config.server_path
   if custom_path and custom_path:gsub("%s+", "") ~= "" then
     if Utils.file_exists(custom_path) then
-      Utils.debug("Using custom server path: " .. custom_path)
+      Logger.debug("Using custom server path: " .. custom_path)
       return custom_path
     else
-      Utils.warn("Custom server path does not exist: " .. custom_path)
+      Logger.notify("Custom server path does not exist: " .. custom_path, vim.log.levels.WARN)
     end
   end
-  
+
   local server_path = self:_get_extension_server_path()
   local latest_version = self:_get_latest_version()
   local current_version = self:_read_version_file()
-  
+
   local server_exists = Utils.file_exists(server_path)
-  
+
   -- If we can't get the latest version and server doesn't exist, that's an error
   if not latest_version and not server_exists then
-    error("Could not fetch latest version of ECA. Please check your internet connection and try again. You can also download ECA manually and set the path in the settings.")
+    error(
+      "Could not fetch latest version of ECA. Please check your internet connection and try again. You can also download ECA manually and set the path in the settings."
+    )
   end
-  
+
   -- Download if server doesn't exist or version is outdated
   if not server_exists or (latest_version and current_version ~= latest_version) then
     if not latest_version then
-      Utils.warn("Could not check for latest version, using existing server")
+      Logger.notify("Could not check for latest version, using existing server", vim.log.levels.WARN)
       return server_path
     end
-    
+
     local success = self:_download_latest_server(server_path, latest_version)
     if not success then
       error("Failed to download ECA server")
     end
   end
-  
-  Utils.debug("Using ECA server: " .. server_path)
+
+  Logger.debug("Using ECA server: " .. server_path)
   return server_path
 end
 

--- a/lua/eca/strings.lua
+++ b/lua/eca/strings.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+---@param s string
+---@return boolean
+function M.is_nil_or_empty(s)
+  return s == nil or s == ""
+end
+
+return M

--- a/lua/eca/utils.lua
+++ b/lua/eca/utils.lua
@@ -1,54 +1,13 @@
 local uv = vim.uv or vim.loop
 
+local Logger = require("eca.logger")
+
 local M = {}
 
 local CONSTANTS = {
   SIDEBAR_FILETYPE = "Eca",
   SIDEBAR_BUFFER_NAME = "__ECA__",
 }
-
----@param msg string
----@param opts? {title?: string, once?: boolean}
-function M.debug(msg, opts)
-  opts = opts or {}
-  local Config = require("eca.config")
-  if Config.debug then
-    vim.notify(msg, vim.log.levels.DEBUG, {
-      title = opts.title or "ECA - Debug",
-      once = opts.once,
-    })
-  end
-end
-
----@param msg string
----@param opts? {title?: string, once?: boolean}
-function M.info(msg, opts)
-  opts = opts or {}
-  vim.notify(msg, vim.log.levels.INFO, {
-    title = opts.title or "ECA",
-    once = opts.once,
-  })
-end
-
----@param msg string
----@param opts? {title?: string, once?: boolean}
-function M.warn(msg, opts)
-  opts = opts or {}
-  vim.notify(msg, vim.log.levels.WARN, {
-    title = opts.title or "ECA",
-    once = opts.once,
-  })
-end
-
----@param msg string
----@param opts? {title?: string, once?: boolean}
-function M.error(msg, opts)
-  opts = opts or {}
-  vim.notify(msg, vim.log.levels.ERROR, {
-    title = opts.title or "ECA",
-    once = opts.once,
-  })
-end
 
 ---@param bufnr integer
 ---@return boolean
@@ -65,7 +24,7 @@ function M.safe_keymap_set(mode, lhs, rhs, opts)
   -- Check if the keymap is already set
   local existing = vim.fn.maparg(lhs, type(mode) == "table" and mode[1] or mode, false, true)
   if existing and existing.rhs then
-    M.debug("Keymap " .. lhs .. " already exists, skipping")
+    Logger.debug("Keymap " .. lhs .. " already exists, skipping")
     return
   end
   vim.keymap.set(mode, lhs, rhs, opts)

--- a/plugin-spec.lua
+++ b/plugin-spec.lua
@@ -9,9 +9,14 @@ return {
   config = function()
     require("eca").setup({
       -- Default configuration
-      debug = false,
       server_path = "",
       server_args = "",
+      log = {
+        display = "split", -- "split" or "popup"
+        level = vim.log.levels.INFO,
+        file = "", -- Empty string uses default path
+        max_file_size_mb = 10,
+      },
       behaviour = {
         auto_set_keymaps = true,
         auto_focus_sidebar = true,

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,6 +1,11 @@
 -- Minimal init.lua for testing
 vim.cmd([[let &rtp.=','.getcwd()]])
 
+-- Disable swap files and other unnecessary features for testing
+vim.o.swapfile = false
+vim.o.backup = false
+vim.o.writebackup = false
+
 -- Add dependencies to runtime path if headless
 if #vim.api.nvim_list_uis() == 0 then
   vim.cmd('set rtp+=deps/mini.nvim')

--- a/tests/test_logging.lua
+++ b/tests/test_logging.lua
@@ -1,0 +1,503 @@
+local MiniTest = require("mini.test")
+local child = MiniTest.new_child_neovim()
+local eq = MiniTest.expect.equality
+local new_set = MiniTest.new_set
+
+local expect_match = MiniTest.new_expectation("string matching", function(str, pattern)
+  return str:find(pattern) ~= nil
+end, function(str, pattern)
+  return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
+end)
+
+local expect_no_match = MiniTest.new_expectation("string not matching", function(str, pattern)
+  return str:find(pattern) == nil
+end, function(str, pattern)
+  return string.format("Pattern: %s\nObserved string: %s", vim.inspect(pattern), str)
+end)
+
+local setup_test_environment = function()
+  child.lua([[
+    _G.test_log_dir = vim.fn.tempname() .. '_logs'
+    vim.fn.mkdir(_G.test_log_dir, 'p')
+
+    _G.captured_notifications = {}
+    local original_notify = vim.notify
+    vim.notify = function(msg, level, opts)
+      table.insert(_G.captured_notifications, {
+        message = msg,
+        level = level,
+        opts = opts or {}
+      })
+      return original_notify(msg, level, opts)
+    end
+  ]])
+end
+
+local cleanup_test_files = function()
+  child.lua([[
+    if _G.test_log_dir then
+      vim.fn.delete(_G.test_log_dir, 'rf')
+    end
+  ]])
+end
+
+--- Get absolute path for a test log file within the temporary test directory
+---
+--- @param filename string The filename within the test directory (e.g., "test.log", "nested/dir/file.log")
+--- @return string Absolute path to the test file
+local get_test_file_path = function(filename)
+  return child.lua_get("_G.test_log_dir") .. "/" .. filename
+end
+
+--- Setup the Logger module with a given configuration in the child Neovim process
+--- Use this when you need custom logger configuration that doesn't fit the common patterns
+--- covered by setup_logger_with_file().
+---
+--- @param config table Logger configuration options (level, file, display, etc.)
+local setup_logger = function(config)
+  child.lua("Logger.setup(...)", { config })
+end
+
+--- Setup logger with a test file and common defaults, with optional overrides
+---
+--- @param filename string The log filename within the test directory
+--- @param overrides? table Optional config overrides (level, display, etc.)
+local setup_logger_with_file = function(filename, overrides)
+  local config = vim.tbl_extend("force", {
+    level = vim.log.levels.INFO,
+    file = get_test_file_path(filename),
+  }, overrides or {})
+  setup_logger(config)
+end
+
+--- Read entire contents of a test log file as a single string
+---
+--- @param relative_path string Path relative to test directory, should start with "/" (e.g., "/test.log")
+--- @return string Complete file contents joined with newlines, or empty string if file not found
+local read_log_file = function(relative_path)
+  return child.lua([[
+    local log_path = _G.test_log_dir .. ']] .. relative_path .. [['
+    if vim.fn.filereadable(log_path) == 1 then
+      return table.concat(vim.fn.readfile(log_path), '\n')
+    end
+    return ''
+  ]])
+end
+
+--- Read only the first line of a test log file
+---
+--- @param relative_path string Path relative to test directory, should start with "/" (e.g., "/test.log")
+--- @return string First line of the file, or empty string if file not found or empty
+---
+--- Example usage:
+---   local first_line = read_log_first_line("/format_test.log")
+---   expect_match(first_line, "%[%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d%]")  -- timestamp format
+local read_log_first_line = function(relative_path)
+  return child.lua([[
+    local log_path = _G.test_log_dir .. ']] .. relative_path .. [['
+    if vim.fn.filereadable(log_path) == 1 then
+      return vim.fn.readfile(log_path)[1] or ''
+    end
+    return ''
+  ]])
+end
+
+--- Wait for async logging operations to complete
+---
+--- @param ms? number Milliseconds to wait (default: 100)
+---
+local wait_for_async = function(ms)
+  vim.uv.sleep(ms or 100)
+end
+
+--- Common test loop: sconfigure logger → run logging code → verify file contents
+---
+--- @param filename string The log filename within the test directory (no leading slash)
+--- @param log_commands string Lua code to execute in child process (usually Logger.* calls)
+--- @param config_overrides? table Optional logger config overrides (level, notify, etc.)
+--- @return string Complete log file contents for assertion testing
+---
+--- Example usage:
+---   -- basic
+---   local contents = log_and_read("test.log", "Logger.info('hello world')")
+---   expect_match(contents, "hello world")
+---
+---   -- Test with custom log level
+---   local contents = log_and_read("debug.log", [[
+---     Logger.debug('debug msg')
+---     Logger.info('info msg')
+---   ]], { level = vim.log.levels.DEBUG })
+---
+---   -- Test multiple log calls
+---   local contents = log_and_read("multi.log", [[
+---     Logger.warn('warning')
+---     Logger.error('error')
+---   ]])
+local log_and_read = function(filename, log_commands, config_overrides)
+  setup_logger_with_file(filename, config_overrides)
+  child.lua(log_commands)
+  wait_for_async()
+  return read_log_file("/" .. filename)
+end
+
+local T = new_set({
+  hooks = {
+    pre_case = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+      child.lua([[Logger = require('eca.logger')]])
+      setup_test_environment()
+    end,
+    post_case = cleanup_test_files,
+    post_once = child.stop,
+  },
+})
+
+T["configuration"] = new_set()
+
+T["configuration"]["default configuration"] = function()
+  child.lua([[
+    Logger.setup()
+  ]])
+
+  eq(child.lua_get("Logger.get_log_path()"), vim.fn.stdpath("state") .. "/eca.log")
+  eq(child.lua_get("Logger.config.level"), vim.log.levels.INFO)
+  eq(child.lua_get("Logger.config.display"), "split")
+end
+
+T["configuration"]["file logging with default path"] = function()
+  setup_logger({
+    level = vim.log.levels.INFO,
+  })
+
+  local log_path = child.lua_get("Logger.get_log_path()")
+  eq(vim.fn.stdpath("state") .. "/eca.log", log_path)
+end
+
+T["configuration"]["file logging with custom path"] = function()
+  setup_logger({
+    level = vim.log.levels.INFO,
+    file = get_test_file_path("custom.log"),
+  })
+
+  local log_path = child.lua_get("Logger.get_log_path()")
+  expect_match(log_path, "custom%.log$")
+end
+
+T["log_levels"] = new_set()
+
+T["log_levels"]["respects minimum log level"] = function()
+  local contents = log_and_read(
+    "level_test.log",
+    [[
+    Logger.debug('debug message')
+    Logger.info('info message')
+    Logger.warn('warn message')
+    Logger.error('error message')
+  ]],
+    { level = vim.log.levels.WARN }
+  )
+
+  expect_no_match(contents, "DEBUG")
+  expect_no_match(contents, "INFO")
+  expect_match(contents, "WARN")
+  expect_match(contents, "ERROR")
+end
+
+T["log_levels"]["invalid level defaults to info"] = function()
+  local contents = log_and_read(
+    "invalid_level.log",
+    [[
+    Logger.debug('debug message')
+    Logger.info('info message')
+  ]],
+    { level = 999 }
+  )
+
+  expect_no_match(contents, "DEBUG")
+  expect_no_match(contents, "INFO")
+end
+
+T["file_logging"] = new_set()
+
+T["file_logging"]["writes to file with correct format"] = function()
+  setup_logger_with_file("format_test.log")
+  child.lua([[Logger.info('test message')]])
+  wait_for_async()
+
+  local contents = read_log_first_line("/format_test.log")
+
+  expect_match(contents, "%[%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d%]")
+  expect_match(contents, "INFO")
+  expect_match(contents, "%[CLIENT%]")
+  expect_match(contents, "test message")
+end
+
+T["file_logging"]["creates parent directory"] = function()
+  setup_logger({
+    level = vim.log.levels.INFO,
+    file = get_test_file_path("nested/dir/test.log"),
+  })
+
+  child.lua([[Logger.info('nested test')]])
+
+  wait_for_async()
+
+  local dir_exists = child.lua([[
+    return vim.fn.isdirectory(_G.test_log_dir .. '/nested/dir') == 1
+  ]])
+  local file_exists = child.lua([[
+    return vim.fn.filereadable(_G.test_log_dir .. '/nested/dir/test.log') == 1
+  ]])
+
+  eq(dir_exists, true)
+  eq(file_exists, true)
+end
+
+T["file_logging"]["supports path expansion"] = function()
+  setup_logger({
+    level = vim.log.levels.INFO,
+    file = "~/test-eca.log",
+  })
+
+  local expanded_path = child.lua_get("Logger.get_log_path()")
+  expect_no_match(expanded_path, "^~")
+  expect_match(expanded_path, "test%-eca%.log$")
+end
+
+T["notifications"] = new_set()
+
+T["notifications"]["Logger.notify sends vim.notify"] = function()
+  setup_logger_with_file("notify_test.log")
+
+  child.lua([[
+    Logger.notify('warning message', vim.log.levels.WARN)
+    Logger.notify('error message', vim.log.levels.ERROR)
+  ]])
+
+  local notifications = child.lua_get("_G.captured_notifications")
+  eq(#notifications, 2)
+  eq(notifications[1].message, "warning message")
+  eq(notifications[1].level, vim.log.levels.WARN)
+  eq(notifications[2].message, "error message")
+  eq(notifications[2].level, vim.log.levels.ERROR)
+end
+
+T["notifications"]["Logger.notify defaults to INFO level"] = function()
+  setup_logger_with_file("notify_default_test.log")
+
+  child.lua([[Logger.notify('default level message')]])
+
+  local notifications = child.lua_get("_G.captured_notifications")
+  eq(#notifications, 1)
+  eq(notifications[1].message, "default level message")
+  eq(notifications[1].level, vim.log.levels.INFO)
+end
+
+T["notifications"]["Logger.notify writes to log file"] = function()
+  local contents = log_and_read(
+    "notify_log_test.log",
+    [[
+    Logger.notify('test notification message', vim.log.levels.WARN)
+  ]]
+  )
+
+  expect_match(contents, "WARN")
+  expect_match(contents, "test notification message")
+  expect_match(contents, "%[CLIENT%]")
+
+  local notifications = child.lua_get("_G.captured_notifications")
+  eq(#notifications, 1)
+  eq(notifications[1].message, "test notification message")
+  eq(notifications[1].level, vim.log.levels.WARN)
+end
+
+T["display modes"] = new_set()
+
+T["display modes"]["default display mode is split"] = function()
+  setup_logger_with_file("display_test.log")
+
+  local display = child.lua_get("Logger.get_display()")
+  eq(display, "split")
+end
+
+T["display modes"]["can configure popup mode"] = function()
+  setup_logger({
+    level = vim.log.levels.INFO,
+    file = get_test_file_path("popup_test.log"),
+    display = "popup",
+  })
+
+  local display = child.lua_get("Logger.get_display()")
+  eq(display, "popup")
+end
+
+T["utilities"] = new_set()
+
+T["utilities"]["get_log_stats"] = function()
+  setup_logger_with_file("stats_test.log")
+
+  child.lua([[Logger.info('message for stats')]])
+
+  wait_for_async()
+
+  local stats = child.lua_get("Logger.get_log_stats()")
+  eq(type(stats), "table")
+  expect_match(stats.path, "stats_test%.log$")
+  eq(type(stats.size), "number")
+  eq(stats.size > 0, true)
+  eq(type(stats.size_mb), "number")
+  eq(type(stats.modified), "string")
+end
+
+T["utilities"]["clear_log"] = function()
+  local content_before = log_and_read("clear_test.log", [[Logger.info('message to be cleared')]])
+  expect_match(content_before, "message to be cleared")
+
+  local cleared = child.lua_get("Logger.clear_log()")
+  eq(cleared, true)
+
+  local content_after = read_log_file("/clear_test.log")
+  eq(content_after, "")
+end
+
+T["integration"] = new_set()
+
+T["integration"]["logger functions work correctly"] = function()
+  local contents = log_and_read(
+    "logger_integration.log",
+    [[
+    Logger.debug('debug message')
+    Logger.info('info message')
+    Logger.warn('warn message')
+    Logger.error('error message')
+  ]],
+    { level = vim.log.levels.DEBUG }
+  )
+
+  expect_match(contents, "debug message")
+  expect_match(contents, "info message")
+  expect_match(contents, "warn message")
+  expect_match(contents, "error message")
+end
+
+T["integration"]["server logging with SERVER prefix"] = function()
+  local contents = log_and_read(
+    "server_integration.log",
+    [[
+    Logger.info('server message 1', { title = 'SERVER' })
+    Logger.warn('server warning', { title = 'SERVER' })
+    Logger.error('server error', { title = 'SERVER' })
+
+    Logger.info('client message')
+  ]]
+  )
+
+  expect_match(contents, "%[SERVER%] server message 1")
+  expect_match(contents, "%[SERVER%] server warning")
+  expect_match(contents, "%[SERVER%] server error")
+  expect_match(contents, "%[CLIENT%] client message")
+end
+
+T["integration"]["EcaLogs command behavior"] = function()
+  setup_logger_with_file("eca_logs_test.log")
+
+  child.lua([[Logger.info('Test log entry for EcaLogs')]])
+
+  wait_for_async()
+
+  local log_path = child.lua_get("Logger.get_log_path()")
+  expect_match(log_path, "eca_logs_test%.log$")
+
+  local api_result = child.lua([[
+    local Api = require('eca.api')
+    local Logger = require('eca.logger')
+
+    local log_path = Logger.get_log_path()
+    return {
+      log_path_exists = vim.fn.filereadable(log_path) == 1,
+      log_path = log_path,
+      file_readable = vim.fn.filereadable(log_path) == 1
+    }
+  ]])
+
+  eq(api_result.log_path_exists, true)
+  eq(api_result.file_readable, true)
+  expect_match(api_result.log_path, "eca_logs_test%.log$")
+end
+
+T["integration"]["EcaLogs subcommands"] = function()
+  setup_logger_with_file("subcommands_test.log")
+
+  child.lua([[
+    Logger.info('Test content for subcommands')
+    Logger.warn('Test warning message')
+  ]])
+
+  wait_for_async()
+
+  local log_path_result = child.lua([[
+    local Logger = require("eca.logger")
+    return Logger.get_log_path()
+  ]])
+  expect_match(log_path_result, "subcommands_test%.log$")
+
+  local stats_result = child.lua([[
+    local Logger = require("eca.logger")
+    return Logger.get_log_stats()
+  ]])
+  eq(type(stats_result), "table")
+  expect_match(stats_result.path, "subcommands_test%.log$")
+  eq(stats_result.size > 0, true)
+
+  local clear_result = child.lua([[
+    local Logger = require("eca.logger")
+    return Logger.clear_log()
+  ]])
+  eq(clear_result, true)
+
+  local file_empty = child.lua([[
+    local Logger = require("eca.logger")
+    local stats = Logger.get_log_stats()
+    return stats and stats.size == 0
+  ]])
+  eq(file_empty, true)
+end
+
+T["integration"]["large log file notification"] = function()
+  -- Create a small log file first
+  setup_logger_with_file("notification_test.log")
+  child.lua([[Logger.info('Initial log entry')]])
+  wait_for_async()
+
+  -- Clear notifications before testing
+  child.lua([[_G.captured_notifications = {}]])
+
+  -- Setup logger with max_file_size_mb = 0 to trigger notification immediately
+  setup_logger({
+    level = vim.log.levels.INFO,
+    file = get_test_file_path("notification_test.log"),
+    max_file_size_mb = 0, -- Set to 0 to trigger notification for any file size
+  })
+
+  wait_for_async(200)
+
+  local notifications = child.lua_get("_G.captured_notifications")
+  eq(#notifications >= 1, true)
+
+  local large_file_notification = nil
+  for _, notification in ipairs(notifications) do
+    if notification.message and notification.message:match("ECA log file is large") then
+      large_file_notification = notification
+      break
+    end
+  end
+
+  eq(large_file_notification ~= nil, true)
+  expect_match(large_file_notification.message, "ECA log file is large")
+  expect_match(large_file_notification.message, "MB%)")
+  expect_match(large_file_notification.message, "Consider clearing it with :EcaLogs clear")
+  eq(large_file_notification.level, vim.log.levels.WARN)
+  eq(large_file_notification.opts.title, "ECA")
+end
+
+return T


### PR DESCRIPTION
Address #16, ~can also address #15~ this is controlled by the sidebar module

[feat(logger): Add a log module](https://github.com/editor-code-assistant/eca-nvim/pull/17/commits/fab84a7d3d0aee9723cfeff3baf5c0d8f2dcfaa9)
Currently the plugin uses vim.notify for almost all logging and can get
quite noisy. Many neovim systems and plugins log to files in
$XDG_STATE_DIR. This introduces a logging module and logs to a default
file. There is also some bookkeeping stuff in here too.

- Add `config.log`
- Default log file is `$XDG_STATE_DIR/nvim/eca.log`
- Default display mode is a buffer, can also display in a popup
- Default log level is vim.log.levels.INFO
- Default max file size before warning is 10MB
- Remove `config.debug`
- Create `Logger` module. Has the regular logging functions as well as
  `Logger.notify` for displaying a notification via `vim.notify`
- Add subcommands to EcaLogs ("show", "log_path", "clear", "stats"),
  `EcaLogs` called with no arguments runs `EcaLogs show`
- Replace calls to Utils logging functions with Logger
- Fix the github action to run the tests

