### PR TITLE
Fix chat headers and make them configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,8 @@ require("eca").setup({
   -- === CHAT ===
   chat = {
     headers = {
-      user = "## 👤 You",
-      assistant = "## 🤖 ECA",
+      user = "## 👤 You\n\n",
+      assistant = "## 🤖 ECA\n\n",
     },
   },
 
@@ -108,8 +108,8 @@ You can customize the chat role headers shown in the sidebar. For example:
 require("eca").setup({
   chat = {
     headers = {
-      user = "## 👨 Me",       -- default: "## 👤 You"
-      assistant = "## 🤖 Copilot", -- default: "## 🤖 ECA"
+      user = "## 👨 Me\n\n",       -- default: "## 👤 You\n\n"
+      assistant = "## 🤖 Assistant\n\n", -- default: "## 🤖 ECA\n\n"
     },
   },
 })

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,14 @@ require("eca").setup({
     toggle = "<leader>et",    -- Toggle sidebar
   },
 
+  -- === CHAT ===
+  chat = {
+    headers = {
+      user = "## 👤 You",
+      assistant = "## 🤖 ECA",
+    },
+  },
+
   -- === WINDOW SETTINGS ===
   windows = {
     -- Automatic line wrapping
@@ -92,6 +100,24 @@ require("eca").setup({
 ```
 
 ---
+
+## Chat headers
+You can customize the chat role headers shown in the sidebar. For example:
+
+```lua
+require("eca").setup({
+  chat = {
+    headers = {
+      user = "## 👨 Me",       -- default: "## 👤 You"
+      assistant = "## 🤖 Copilot", -- default: "## 🤖 ECA"
+    },
+  },
+})
+```
+
+Notes:
+- These are plain strings; they will be printed verbatim as a single line.
+- A blank line is automatically inserted after the header.
 
 ## Presets
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,24 +101,6 @@ require("eca").setup({
 
 ---
 
-## Chat headers
-You can customize the chat role headers shown in the sidebar. For example:
-
-```lua
-require("eca").setup({
-  chat = {
-    headers = {
-      user = "## 👨 Me\n\n",       -- default: "## 👤 You\n\n"
-      assistant = "## 🤖 Assistant\n\n", -- default: "## 🤖 ECA\n\n"
-    },
-  },
-})
-```
-
-Notes:
-- These are plain strings; they will be printed verbatim as a single line.
-- A blank line is automatically inserted after the header.
-
 ## Presets
 
 ### Minimalist
@@ -126,6 +108,12 @@ Notes:
 require("eca").setup({
   behaviour = { show_status_updates = false },
   windows = { width = 30 },
+  chat = {
+    headers = {
+      user = "> ",
+      assistant = "",
+    },
+  },
 })
 ```
 
@@ -138,6 +126,12 @@ require("eca").setup({
     wrap = true,
     sidebar_header = { enabled = true, rounded = true },
     input = { prefix = "💬 ", height = 10 },
+  },
+  chat = {
+    headers = {
+      user = "## 👤 You\n\n",
+      assistant = "## 🤖 ECA\n\n",
+    },
   },
 })
 ```

--- a/lua/eca/config.lua
+++ b/lua/eca/config.lua
@@ -45,8 +45,8 @@ M._defaults = {
   },
   chat = {
     headers = {
-      user = "## 👤 You",
-      assistant = "## 🤖 ECA",
+      user = "## 👤 You\n\n",
+      assistant = "## 🤖 ECA\n\n",
     },
   },
   windows = {

--- a/lua/eca/config.lua
+++ b/lua/eca/config.lua
@@ -43,6 +43,12 @@ M._defaults = {
     focus = "<leader>ef",
     toggle = "<leader>et",
   },
+  chat = {
+    headers = {
+      user = "## 👤 You",
+      assistant = "## 🤖 ECA",
+    },
+  },
   windows = {
     wrap = true,
     width = 40, -- Window width as percentage (40 = 40% of screen width)

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -26,6 +26,7 @@ local Split = require("nui.split")
 ---@field private _response_start_time number Timestamp when streaming started
 ---@field private _max_response_length number Maximum allowed response length
 ---@field private _headers table Table of headers for the chat
+
 local M = {}
 M.__index = M
 

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1161,6 +1161,9 @@ function M:_send_message(message)
   -- Store the last user message to avoid duplication
   self._last_user_message = message
 
+  -- Add user message to chat
+  self:_add_message("user", message)
+
   local contexts = self:get_contexts()
   self.mediator:send("chat/prompt", {
     chatId = self.id,
@@ -1272,6 +1275,11 @@ function M:_handle_streaming_text(text)
     return
   end
   Logger.debug("Received text chunk: '" .. text:sub(1, 50) .. (text:len() > 50 and "..." or "") .. "'")
+
+  if vim.trim(text) == vim.trim(self._last_user_message) then
+    Logger.debug("Ignoring duplicate user message in response")
+    return
+  end
 
   if not self._is_streaming then
     Logger.debug("Starting streaming response")

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -25,6 +25,7 @@ local Split = require("nui.split")
 ---@field private _augroup integer Autocmd group ID
 ---@field private _response_start_time number Timestamp when streaming started
 ---@field private _max_response_length number Maximum allowed response length
+---@field private _headers table Table of headers for the chat
 local M = {}
 M.__index = M
 
@@ -58,6 +59,10 @@ function M.new(id, mediator)
   instance._augroup = vim.api.nvim_create_augroup("eca_sidebar_" .. id, { clear = true })
   instance._response_start_time = 0
   instance._max_response_length = 50000 -- 50KB max response
+  instance._headers = {
+    user = (Config.chat and Config.chat.headers and Config.chat.headers.user) or "## 👤 You\n\n",
+    assistant = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "## 🤖 ECA\n\n",
+  }
 
   require("eca.observer").subscribe(id, function(message)
     instance:handle_chat_content(message)
@@ -874,6 +879,7 @@ function M:_set_welcome_content()
     "- **RepoMap**: Use `:EcaAddRepoMap` to add repository structure context",
     "",
     "---",
+    ""
   }
 
   Logger.debug("Setting welcome content for new chat")
@@ -1271,7 +1277,7 @@ end
 function M:_handle_streaming_text(text)
   -- Only check for empty text
   if not text or text == "" then
-    Logger.trace("Ignoring empty text response")
+    Logger.debug("Ignoring empty text response")
     return
   end
   Logger.debug("Received text chunk: '" .. text:sub(1, 50) .. (text:len() > 50 and "..." or "") .. "'")
@@ -1319,10 +1325,13 @@ function M:_update_streaming_message(content)
     -- Make buffer modifiable
     vim.api.nvim_set_option_value("modifiable", true, { buf = chat.bufnr })
 
+    -- Concat content with header
+    content = self._headers.assistant .. content
+
     -- Get current lines
     local lines = vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false)
     local content_lines = Utils.split_lines(content)
-    local start_line = self._last_assistant_line + 2 -- Skip "## 🤖 ECA" and empty line
+    local start_line = self._last_assistant_line
 
     Logger.debug("DEBUG: Assistant line: " .. self._last_assistant_line .. ", start_line: " .. start_line)
     Logger.debug("DEBUG: Content lines: " .. #content_lines)
@@ -1367,25 +1376,16 @@ function M:_add_message(role, content)
 
   self:_safe_buffer_update(chat.bufnr, function()
     local lines = vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false)
-
-    -- Add separator if not the first message
-    if #lines > 0 and lines[#lines] ~= "" then
-      table.insert(lines, "")
-      table.insert(lines, "---")
-      table.insert(lines, "")
-    end
-
-    -- Add role header with better markdown formatting (configurable)
-    local user_header = (Config.chat and Config.chat.headers and Config.chat.headers.user) or "## 👤 You"
-    local assistant_header = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "## 🤖 ECA"
+    local header = ""
 
     if role == "user" then
-      table.insert(lines, user_header)
-    else
-      table.insert(lines, assistant_header)
+      header = self._headers.user
+    elseif role == "assistant" then
+      header = self._headers.assistant
     end
 
-    table.insert(lines, "")
+    -- Concat header and content
+    content = header .. content
 
     -- Add content with better markdown formatting
     local content_lines = Utils.split_lines(content)
@@ -1413,7 +1413,9 @@ function M:_add_message(role, content)
       end
     end
 
-    table.insert(lines, "")
+    if header ~= "" then
+      table.insert(lines, "")
+    end
 
     -- Update buffer safely
     vim.api.nvim_buf_set_lines(chat.bufnr, 0, -1, false, lines)
@@ -1472,7 +1474,19 @@ function M:_get_last_message_line()
   end
 
   local lines = vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false)
-  local assistant_header = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "## 🤖 ECA"
+
+  Logger.debug("DEBUG: Finding last assistant message line in " .. #lines .. " lines")
+  Logger.debug("DEBUG: Finding last assistant message line in " .. vim.inspect(lines) .. " lines")
+
+  local assistant_header_lines = Utils.split_lines(self._headers.assistant)
+  local assistant_header = ""
+
+  for i = #assistant_header_lines, 1, -1 do
+    if assistant_header_lines[i] and assistant_header_lines[i] ~= "" then
+      assistant_header = assistant_header_lines[i]
+      break
+    end
+  end
 
   for i = #lines, 1, -1 do
     local line = lines[i]

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1474,10 +1474,6 @@ function M:_get_last_message_line()
   end
 
   local lines = vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false)
-
-  Logger.debug("DEBUG: Finding last assistant message line in " .. #lines .. " lines")
-  Logger.debug("DEBUG: Finding last assistant message line in " .. vim.inspect(lines) .. " lines")
-
   local assistant_header_lines = Utils.split_lines(self._headers.assistant)
   local assistant_header = ""
 

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1367,11 +1367,14 @@ function M:_add_message(role, content)
       table.insert(lines, "")
     end
 
-    -- Add role header with better markdown formatting
+    -- Add role header with better markdown formatting (configurable)
+    local user_header = (Config.chat and Config.chat.headers and Config.chat.headers.user) or "## 👤 You"
+    local assistant_header = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "## 🤖 ECA"
+
     if role == "user" then
-      table.insert(lines, "## 👤 You")
+      table.insert(lines, user_header)
     else
-      table.insert(lines, "## 🤖 ECA")
+      table.insert(lines, assistant_header)
     end
 
     table.insert(lines, "")
@@ -1461,8 +1464,11 @@ function M:_get_last_message_line()
   end
 
   local lines = vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false)
+  local assistant_header = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "## 🤖 ECA"
+
   for i = #lines, 1, -1 do
-    if lines[i] and lines[i]:match("^## 🤖 ECA") then
+    local line = lines[i]
+    if line and line:sub(1, #assistant_header) == assistant_header then
       return i
     end
   end

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1413,7 +1413,7 @@ function M:_add_message(role, content)
       end
     end
 
-    if header ~= "" then
+    if content ~= "" then
       table.insert(lines, "")
     end
 


### PR DESCRIPTION
# Context

Header `## 👤 You` was not being displayed for user messages:

## Before

<img width="776" height="146" alt="Screenshot 2025-09-07 at 19 21 41" src="https://github.com/user-attachments/assets/3b93f01b-89aa-4ad7-8de0-21b468dbae66" />

## After

<img width="775" height="205" alt="Screenshot 2025-09-07 at 19 21 06" src="https://github.com/user-attachments/assets/98087236-0449-4b83-b4ea-f3e919f3eddd" />

## After with custom headers 

This PR also add the option to configure custom headers such as:

```lua
require('eca').setup({
  chat = {
    headers = {
      user = "> ",
      assistant = "",
    },
  },
})
```

<img width="773" height="119" alt="Screenshot 2025-09-07 at 19 24 21" src="https://github.com/user-attachments/assets/210b8517-3d2d-4fcd-8a39-fcf6613b1a99" />

