### PR TITLE
Display model, behavior, agent and usage based on server `config/updated` message

### DIFF
--- a/lua/eca/init.lua
+++ b/lua/eca/init.lua
@@ -242,8 +242,9 @@ function M.setup(opts)
   H.signs()
 
   -- Initialize the ECA server with callbacks
+  M.state = require("eca.state").new()
   M.server = Server.new()
-  M.mediator = require("eca.mediator").new(M.server)
+  M.mediator = require("eca.mediator").new(M.server, M.state)
   -- Start server automatically in background
   vim.defer_fn(function()
     M.server:start()

--- a/lua/eca/mediator.lua
+++ b/lua/eca/mediator.lua
@@ -1,12 +1,15 @@
 ---@class eca.Mediator
 ---@field server eca.Server
+---@field state eca.State
 local mediator = {}
 
 ---@param server eca.Server
+---@param state eca.State
 ---@return eca.Mediator
-function mediator.new(server)
+function mediator.new(server, state)
   return setmetatable({
     server = server,
+    state = state,
   }, { __index = mediator })
 end
 
@@ -21,6 +24,46 @@ function mediator:send(method, params, callback)
     require("eca.logger").notify("Server is not rnning, please start the server", vim.log.levels.WARN)
   end
   self.server:send_request(method, params, callback)
+end
+
+function mediator:selected_behavior()
+  return self.state.config.behaviors.selected
+end
+
+function mediator:selected_model()
+  return self.state.config.models.selected
+end
+
+function mediator:tokens_session()
+  return self.state.usage.tokens.session
+end
+
+function mediator:tokens_limit()
+  return self.state.usage.tokens.limit
+end
+
+function mediator:costs_session()
+  return self.state.usage.costs.session
+end
+
+function mediator:status_state()
+  return self.state.status.state
+end
+
+function mediator:status_text()
+  return self.state.status.text
+end
+
+function mediator:mcps()
+  local mcps = {}
+
+  for _, tool in pairs(self.state.tools) do
+    if tool.type == "mcp" then
+      table.insert(mcps, tool)
+    end
+  end
+
+  return mcps
 end
 
 return mediator

--- a/lua/eca/observer.lua
+++ b/lua/eca/observer.lua
@@ -1,9 +1,9 @@
 local observer = {}
 
----@type { [integer]: fun(message: table) }
+---@type { [string]: fun(message: table) }
 local subscriptions = {}
 
----@param id integer
+---@param id string
 ---@param on_update fun(message: table)
 function observer.subscribe(id, on_update)
   subscriptions[id] = on_update

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -31,7 +31,10 @@ local M = {}
 M.__index = M
 
 -- Height calculation constants
+local MIN_CHAT_HEIGHT = 10 -- Minimum lines for chat container to remain usable
+local WINDOW_MARGIN = 3 -- Additional margin for window borders and spacing
 local UI_ELEMENTS_HEIGHT = 2 -- Reserve space for statusline and tabline
+local SAFETY_MARGIN = 2 -- Extra margin to prevent "Not enough room" errors
 
 ---@param id integer Tab ID
 ---@param mediator eca.Mediator
@@ -230,6 +233,12 @@ function M:_create_containers()
 
   -- Validate total height to prevent "Not enough room" error
   local total_height = chat_height
+    + selected_code_height
+    + todos_height
+    + status_height
+    + contexts_height
+    + input_height
+    + usage_height
     + config_height
 
   -- Always calculate from total screen minus UI elements (more accurate than current window)
@@ -567,6 +576,13 @@ function M:get_chat_height()
   return math.max(
     MIN_CHAT_HEIGHT,
     total_height
+      - input_height
+      - usage_height
+      - status_height
+      - contexts_height
+      - selected_code_height
+      - todos_height
+      - WINDOW_MARGIN
       - config_height
   )
 end
@@ -1442,6 +1458,12 @@ function M:_add_message(role, content)
 
     -- Check if content looks like code (starts with common programming patterns)
     local is_code = content:match("^%s*function")
+      or content:match("^%s*class")
+      or content:match("^%s*def ")
+      or content:match("^%s*import")
+      or content:match("^%s*#include")
+      or content:match("^%s*<%?")
+      or content:match("^%s*<html")
 
     if is_code then
       -- Wrap in code block with auto-detection

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1086,12 +1086,26 @@ function M:_update_config_display()
 
   local model = self.mediator:selected_model() or "unknown"
   local behavior = self.mediator:selected_behavior() or "unknown"
-  local mcps = vim.tbl_count(self.mediator:mcps())
+  local mcps = self.mediator:mcps()
+
+  local mcps_hl = "Normal"
+
+  for _, mcp in pairs(mcps) do
+    if mcp.status == "starting" then
+      mcps_hl = "Comment"
+      break
+    end
+
+    if mcp.status == "failed" then
+      mcps_hl = "Exception"
+      break
+    end
+  end
 
   local texts = {
     { "model:",    "Comment" }, { model, "Normal" }, { "\t" },
     { "behavior:", "Comment" }, { behavior, "Normal" }, { " " },
-    { "mcps:", "Comment" }, { tostring(mcps), "Exception" },
+    { "mcps:", "Comment" }, { tostring(vim.tbl_count(mcps)), mcps_hl },
   }
 
   local virt_opts = { virt_text = texts, hl_mode = "combine" }
@@ -1188,7 +1202,7 @@ function M:_update_usage_info()
     -1,
     vim.tbl_extend("force",
       {
-        virt_text = { { self._current_status, (status_text ~= "Idle") and "Question" or "Normal" } },
+        virt_text = { { self._current_status, (status_text ~= "Idle") and "Debug" or "Normal" } },
         virt_text_pos = 'eol',
         hl_mode = 'combine',
       },

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1104,6 +1104,10 @@ function M:_update_config_display()
     }
   end
 
+  vim.api.nvim_set_option_value("modifiable", true, { buf = config.bufnr })
+  vim.api.nvim_buf_set_lines(config.bufnr, 0, -1, false, { "" })
+  vim.api.nvim_set_option_value("modifiable", false, { buf = config.bufnr })
+
   self.extmarks.config._id = vim.api.nvim_buf_set_extmark(
     config.bufnr,
     self.extmarks.config._ns,

--- a/lua/eca/state.lua
+++ b/lua/eca/state.lua
@@ -1,0 +1,201 @@
+---@class eca.StateStatus
+---@field state string
+---@field text string
+
+---@class eca.StateConfig
+---@field welcome_message string?
+---@field behaviors { list: string[], default: string?, selected: string? }
+---@field models { list: string[], default: string?, selected: string? }
+
+---@class eca.StateUsage
+---@field tokens { limit: number, session: number }
+---@field costs { last_message: string, session: string }
+
+---@class eca.StateTool
+---@field type string
+---@field name string
+---@field status string
+---
+---@class eca.State
+---@field status eca.StateStatus
+---@field config eca.StateConfig
+---@field usage eca.StateUsage
+---@field tools table<string, eca.StateTool>
+local State = {}
+
+---@return eca.State
+function State._new()
+  local instance = setmetatable({
+    status = {
+      state = "idle",
+      text = "Idle",
+    },
+    config = {
+      welcome_message = nil,
+      behaviors = {
+        list = {},
+        default = nil,
+        selected = nil,
+      },
+      models = {
+        list = {},
+        default = nil,
+        selected = nil,
+      },
+    },
+    usage = {
+      tokens = {
+        limit = 0,
+        session = 0,
+      },
+      costs = {
+        last_message = "0.00",
+        session = "0.00",
+      },
+    },
+    tools = {},
+  }, { __index = State })
+
+  local handlers = {
+    ["chat/contentReceived"] = function(message) instance:_chat_content_received(message) end,
+    ["config/updated"] = function(message) instance:_config_updated(message) end,
+    ["tool/serverUpdated"] = function(message) instance:_tool_server_updated(message) end,
+  }
+
+  require("eca.observer").subscribe("state-1", function(message)
+    if not message or not message.method then
+      return
+    end
+
+    local handler = handlers[message.method]
+
+    if not handler or type(handler) ~= 'function' then
+      return
+    end
+
+    handler(message)
+  end)
+
+  return instance
+end
+
+local _instance
+
+---@return eca.State
+function State.new()
+  if not _instance then
+    _instance = State._new()
+  end
+
+  return _instance
+end
+
+function State:_chat_content_received(message)
+  if not message or not message.params then
+    return
+  end
+
+  if not message.params.content or not message.params.content.type then
+    return
+  end
+
+  local content = message.params.content
+
+  if content.type == "progress" then
+    self:_update_status(content)
+  end
+
+  if content.type == "usage" then
+    self:_update_usage(content)
+  end
+end
+
+function State:_config_updated(message)
+  if not message or not message.params then
+    return
+  end
+
+  if not message.params.chat or type(message.params.chat) ~= "table" then
+    return
+  end
+
+  self:_update_config({ chat = vim.deepcopy(message.params.chat) })
+end
+
+function State:_tool_server_updated(message)
+  if not message or not message.params then
+    return
+  end
+
+  self:_update_tools(message.params)
+end
+
+function State:_update_config(config)
+  local chat = config.chat
+
+  if not chat or type(chat) ~= "table" then
+    return
+  end
+
+  self.config.behaviors = {
+    list = (chat.behaviors and vim.deepcopy(chat.behaviors)) or self.config.behaviors.list,
+    default = (chat.defaultBehavior) or self.config.behaviors.default,
+    selected = (chat.selectBehavior) or self.config.behaviors.selected,
+  }
+
+  self.config.models = {
+    list = (chat.models and vim.deepcopy(chat.models)) or self.config.models.list,
+    default = (chat.defaultModel) or self.config.models.default,
+    selected = (chat.selectModel) or self.config.models.selected,
+  }
+
+  self.config.welcome_message = (chat and chat.welcomeMessage) or self.config.welcome_message
+
+  vim.schedule(function()
+    require("eca.observer").notify({ type = "state/updated", content = { config = vim.deepcopy(self.config) } })
+  end)
+end
+
+function State:_update_status(status)
+  self.status.state = status.state or self.status.state
+  self.status.text = status.text or self.status.text
+
+  vim.schedule(function()
+    require("eca.observer").notify({ type = "state/updated", content = { status = vim.deepcopy(self.status) } })
+  end)
+end
+
+function State:_update_usage(usage)
+  self.usage = {
+    tokens = {
+      limit = (usage.limit and usage.limit.output) or self.usage.tokens.limit,
+      session = usage.sessionTokens or self.usage.tokens.session,
+    },
+    costs = {
+      last_message = usage.lastMessageCost or self.usage.costs.last_message,
+      session = usage.sessionCost or self.usage.costs.session,
+    },
+  }
+
+  vim.schedule(function()
+    require("eca.observer").notify({ type = "state/updated", content = { usage = vim.deepcopy(self.usage) } })
+  end)
+end
+
+function State:_update_tools(tool)
+  if not tool.name then
+    return
+  end
+
+  self.tools[tool.name] = {
+    name = tool.name,
+    type = tool.type or (self.tools[tool.name] and self.tools[tool.name].type) or "unknown",
+    status = tool.status or (self.tools[tool.name] and self.tools[tool.name].status) or "unknown",
+  }
+
+  vim.schedule(function()
+    require("eca.observer").notify({ type = "state/updated", content = { tools = vim.deepcopy(self.tools) } })
+  end)
+end
+
+return State


### PR DESCRIPTION
## Context
* Introduced a new `eca.State` object for centralized state management, passed to the mediator for accessing configuration, usage, and tool information. 
* The mediator now exposes methods for retrieving selected model/behavior, token/cost/session info, and tool lists.
* Added a new `config` container to the sidebar, displaying selected model, behavior, and MCP count. 
* Refactored usage info display logic to properly works with the server message and also moved status there.
* Added the `EcaServerMessages` user command, enabling users to interactively inspect messages sent to and received from the ECA server via a picker interface. 

## Before

![output](https://github.com/user-attachments/assets/c2872889-f596-460a-98cf-eb766025b503)

## After

![output_2](https://github.com/user-attachments/assets/dc0ef7a4-b75d-4bb0-8563-8d656191aa72)