### PR TITLE
Update default headers and welcome message

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,16 @@ require("eca").setup({
   -- === CHAT ===
   chat = {
     headers = {
-      user = "## 👤 You\n\n",
-      assistant = "## 🤖 ECA\n\n",
+      user = "> ",
+      assistant = "",
+    },
+    welcome = {
+      -- If non-empty, overrides server-provided welcome message
+      message = "",
+      -- Tips appended under the welcome (set {} to disable)
+      tips = {
+        "Type your message and use CTRL+s to send",
+      },
     },
   },
 

--- a/lua/eca/config.lua
+++ b/lua/eca/config.lua
@@ -48,6 +48,12 @@ M._defaults = {
       user = "> ",
       assistant = "",
     },
+    welcome = {
+      message = "", -- If non-empty, overrides server-provided welcome message
+      tips = {
+        "Type your message and use CTRL+s to send", -- Tips appended under the welcome (set empty list {} to disable)
+      },
+    },
   },
   windows = {
     wrap = true,

--- a/lua/eca/config.lua
+++ b/lua/eca/config.lua
@@ -45,8 +45,8 @@ M._defaults = {
   },
   chat = {
     headers = {
-      user = "## 👤 You\n\n",
-      assistant = "## 🤖 ECA\n\n",
+      user = "> ",
+      assistant = "",
     },
   },
   windows = {

--- a/lua/eca/mediator.lua
+++ b/lua/eca/mediator.lua
@@ -54,6 +54,10 @@ function mediator:status_text()
   return self.state.status.text
 end
 
+function mediator:welcome_message()
+  return (self.state and self.state.config and self.state.config.welcome_message) or nil
+end
+
 function mediator:mcps()
   local mcps = {}
 

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -62,8 +62,8 @@ function M.new(id, mediator)
   instance._response_start_time = 0
   instance._max_response_length = 50000 -- 50KB max response
   instance._headers = {
-    user = (Config.chat and Config.chat.headers and Config.chat.headers.user) or "## 👤 You\n\n",
-    assistant = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "## 🤖 ECA\n\n",
+    user = (Config.chat and Config.chat.headers and Config.chat.headers.user) or "> ",
+    assistant = (Config.chat and Config.chat.headers and Config.chat.headers.assistant) or "",
   }
 
   require("eca.observer").subscribe("sidebar-" .. id, function(message)
@@ -1376,8 +1376,32 @@ function M:_handle_streaming_text(text)
     -- Start streaming - simple and direct
     self._is_streaming = true
     self._current_response_buffer = ""
+
+    -- Determine insertion point before adding placeholder (works even with empty header)
+    local chat = self.containers.chat
+    local start_line = 1
+    if chat and vim.api.nvim_buf_is_valid(chat.bufnr) then
+      start_line = vim.api.nvim_buf_line_count(chat.bufnr) + 1
+    end
+
+    -- Add assistant placeholder and track its start line
     self:_add_message("assistant", "")
-    self._last_assistant_line = self:_get_last_message_line()
+    self._last_assistant_line = start_line
+
+    -- Track placeholder with an extmark independent of header content
+    self.extmarks = self.extmarks or {}
+    if not self.extmarks.assistant then
+      self.extmarks.assistant = { _ns = vim.api.nvim_create_namespace('extmarks_assistant') }
+    end
+    if chat and vim.api.nvim_buf_is_valid(chat.bufnr) then
+      self.extmarks.assistant._id = vim.api.nvim_buf_set_extmark(
+        chat.bufnr,
+        self.extmarks.assistant._ns,
+        start_line - 1,
+        0,
+        { id = self.extmarks.assistant._id }
+      )
+    end
   end
 
   -- Simple accumulation - no complex checks
@@ -1415,9 +1439,17 @@ function M:_update_streaming_message(content)
     -- Get current lines
     local lines = vim.api.nvim_buf_get_lines(chat.bufnr, 0, -1, false)
     local content_lines = Utils.split_lines(content)
-    local start_line = self._last_assistant_line
 
-    Logger.debug("DEBUG: Assistant line: " .. self._last_assistant_line .. ", start_line: " .. start_line)
+    -- Resolve assistant start line using extmark if available
+    local start_line = self._last_assistant_line
+    if self.extmarks and self.extmarks.assistant and self.extmarks.assistant._id then
+      local pos = vim.api.nvim_buf_get_extmark_by_id(chat.bufnr, self.extmarks.assistant._ns, self.extmarks.assistant._id, {})
+      if pos and pos[1] then
+        start_line = pos[1] + 1
+      end
+    end
+
+    Logger.debug("DEBUG: Assistant line: " .. tostring(self._last_assistant_line) .. ", start_line: " .. tostring(start_line))
     Logger.debug("DEBUG: Content lines: " .. #content_lines)
 
     -- Replace assistant content directly
@@ -1438,6 +1470,19 @@ function M:_update_streaming_message(content)
 
     -- Set all lines at once
     vim.api.nvim_buf_set_lines(chat.bufnr, 0, -1, false, new_lines)
+
+    -- Re-anchor the assistant extmark at the start line (for subsequent updates)
+    self.extmarks = self.extmarks or {}
+    if not self.extmarks.assistant then
+      self.extmarks.assistant = { _ns = vim.api.nvim_create_namespace('extmarks_assistant') }
+    end
+    self.extmarks.assistant._id = vim.api.nvim_buf_set_extmark(
+      chat.bufnr,
+      self.extmarks.assistant._ns,
+      start_line - 1,
+      0,
+      { id = self.extmarks.assistant._id }
+    )
 
     Logger.debug("DEBUG: Buffer updated successfully with " .. #new_lines .. " total lines")
   end)
@@ -1519,6 +1564,13 @@ function M:_finalize_streaming_response()
     self._current_response_buffer = ""
     self._last_assistant_line = 0
     self._response_start_time = 0
+
+    -- Clear assistant placeholder tracking extmark
+    local chat = self.containers.chat
+    if chat and vim.api.nvim_buf_is_valid(chat.bufnr) and self.extmarks and self.extmarks.assistant then
+      pcall(vim.api.nvim_buf_clear_namespace, chat.bufnr, self.extmarks.assistant._ns, 0, -1)
+      self.extmarks.assistant._id = nil
+    end
 
     Logger.debug("DEBUG: Streaming state cleared")
   else


### PR DESCRIPTION
## Context

* Added support for a configurable welcome message and tips in the chat UI, allowing users to override the server-provided message and display helpful usage hints.
* Changed default chat headers for user and assistant messages to simpler formats (matching eca-emacs).
* Implemented tracking of the assistant message insertion point using extmarks instead of assistant header string, ensuring it works when assistant header is empty. 