### PR TITLE
feat: send chat/promptStop to server on EcaStopResponse

### DIFF
--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1716,6 +1716,11 @@ function M:_add_message(role, content)
 end
 function M:_finalize_streaming_response()
   if self._is_streaming then
+    local chat_id = self.mediator:id()
+    if chat_id then
+      self.mediator:send("chat/promptStop", { chatId = chat_id }, nil)
+    end
+
     Logger.debug("DEBUG: Finalizing streaming response")
     Logger.debug("DEBUG: Final buffer had " .. #(self._current_response_buffer or "") .. " chars")
 


### PR DESCRIPTION
`:EcaStopResponse` only finalized local streaming UI — server kept generating. Now sends `chat/promptStop` notification before cleanup, matching eca-emacs behavior.

5-line change inside `_finalize_streaming_response`, guarded on chat ID + streaming state.