### PR TITLE
feat: send chat/clear to server on EcaChatClear

### DIFF
--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -256,6 +256,11 @@ end
 function M:clear_chat()
   local chat = self.containers and self.containers.chat
   if chat and chat.bufnr and vim.api.nvim_buf_is_valid(chat.bufnr) then
+    local chat_id = self.mediator:id()
+    if chat_id then
+      self.mediator:send("chat/clear", { chatId = chat_id, messages = true }, nil)
+    end
+
     -- Reset chat content state to prevent stale line numbers / extmark IDs.
     self._tool_calls = {}
     self._reasons = {}


### PR DESCRIPTION
`:EcaChatClear` only wiped the local buffer — server retained full chat history. Now sends `chat/clear` request with `messages: true` before local cleanup, matching eca-emacs behavior.

5-line change inside existing buffer-validity guard in `clear_chat()`.