### PR TITLE
feat: implement editor/getDiagnostics protocol support

### DIFF
--- a/lua/eca/editor.lua
+++ b/lua/eca/editor.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+local SEVERITY = {
+  [vim.diagnostic.severity.ERROR] = "error",
+  [vim.diagnostic.severity.WARN]  = "warning",
+  [vim.diagnostic.severity.INFO]  = "information",
+  [vim.diagnostic.severity.HINT]  = "hint",
+}
+
+local function uri_to_bufnr(uri)
+  if not uri or uri == "" then return -1 end
+  local path = vim.uri_to_fname(uri)
+  return vim.fn.bufnr(path)
+end
+
+local function get_diagnostics(params)
+  local uri = params.uri
+  local bufnr = uri_to_bufnr(uri)
+  if bufnr == -1 then return { diagnostics = {} } end
+  local raw = vim.diagnostic.get(bufnr)
+  local diags = {}
+  for _, d in ipairs(raw) do
+    table.insert(diags, {
+      uri      = uri,
+      message  = d.message,
+      severity = SEVERITY[d.severity] or "information",
+      range = {
+        start   = { line = d.lnum,             character = d.col },
+        ["end"] = { line = d.end_lnum or d.lnum, character = d.end_col or d.col },
+      },
+      source = d.source,
+      code   = d.code,
+    })
+  end
+  return { diagnostics = diags }
+end
+
+function M.handle_request(message)
+  if message.method == "editor/getDiagnostics" then
+    return get_diagnostics(message.params or {})
+  end
+  return {}
+end
+
+return M

--- a/lua/eca/editor.lua
+++ b/lua/eca/editor.lua
@@ -39,7 +39,7 @@ function M.handle_request(message)
   if message.method == "editor/getDiagnostics" then
     return get_diagnostics(message.params or {})
   end
-  return {}
+  return nil
 end
 
 return M

--- a/lua/eca/server.lua
+++ b/lua/eca/server.lua
@@ -37,6 +37,9 @@ function M.new(opts)
         require("eca.observer").notify(message)
       end)
     end,
+    on_request = function(_, message)
+      return require("eca.editor").handle_request(message)
+    end,
     cwd = vim.fn.getcwd(),
     workspace_folders = {
       {
@@ -52,6 +55,7 @@ function M.new(opts)
     on_initialize = opts.on_initialize,
     on_stop = opts.on_stop,
     on_notification = opts.on_notification,
+    on_request = opts.on_request,
     messages = {},
     pending_requests = {},
     initialized = false,
@@ -201,6 +205,7 @@ function M:initialize()
     capabilities = {
       codeAssistant = {
         chat = true,
+        editor = { diagnostics = true },
       },
     },
     workspaceFolders = vim.deepcopy(self.workspace_folders),
@@ -255,11 +260,36 @@ function M:handle_message(message)
     else
       callback(nil, message.result)
     end
+  elseif message.id and message.method then
+    if self.on_request then
+      local id = message.id
+      vim.schedule(function()
+        local ok, result = pcall(self.on_request, self, message)
+        if not ok then
+          Logger.error("on_request error: " .. tostring(result))
+          self:send_response(id, {})
+          return
+        end
+        local ok2, err = pcall(self.send_response, self, id, result)
+        if not ok2 then
+          Logger.error("send_response error: " .. tostring(err))
+        end
+      end)
+    end
   elseif message.method and not message.id then
     if self.on_notification then
       self:on_notification(message)
     end
   end
+end
+
+---@param id integer|string
+---@param result table
+function M:send_response(id, result)
+  local message = { jsonrpc = "2.0", id = id, result = result }
+  local json = vim.json.encode(message)
+  local content = string.format("Content-Length: %d\r\n\r\n%s", #json, json)
+  self.process:write(content)
 end
 
 ---@return integer

--- a/lua/eca/server.lua
+++ b/lua/eca/server.lua
@@ -267,7 +267,11 @@ function M:handle_message(message)
         local ok, result = pcall(self.on_request, self, message)
         if not ok then
           Logger.error("on_request error: " .. tostring(result))
-          self:send_response(id, {})
+          pcall(self.send_error_response, self, id, -32603, "Internal error")
+          return
+        end
+        if result == nil then
+          pcall(self.send_error_response, self, id, -32601, "Method not found")
           return
         end
         local ok2, err = pcall(self.send_response, self, id, result)
@@ -286,7 +290,25 @@ end
 ---@param id integer|string
 ---@param result table
 function M:send_response(id, result)
+  if not self:is_running() then
+    Logger.error("send_response: server not running, dropping response for id=" .. tostring(id))
+    return
+  end
   local message = { jsonrpc = "2.0", id = id, result = result }
+  local json = vim.json.encode(message)
+  local content = string.format("Content-Length: %d\r\n\r\n%s", #json, json)
+  self.process:write(content)
+end
+
+---@param id integer|string
+---@param code integer JSON-RPC error code
+---@param msg string
+function M:send_error_response(id, code, msg)
+  if not self:is_running() then
+    Logger.error("send_error_response: server not running, dropping error for id=" .. tostring(id))
+    return
+  end
+  local message = { jsonrpc = "2.0", id = id, error = { code = code, message = msg } }
   local json = vim.json.encode(message)
   local content = string.format("Content-Length: %d\r\n\r\n%s", #json, json)
   self.process:write(content)

--- a/tests/test_editor_diagnostics.lua
+++ b/tests/test_editor_diagnostics.lua
@@ -14,13 +14,13 @@ local T = MiniTest.new_set({
 T["editor"] = MiniTest.new_set()
 
 T["editor"]["returns empty diagnostics when buffer not found"] = function()
-  local count = child.lua_get([[
+  local diagnostics = child.lua_get([[
     require("eca.editor").handle_request({
       method = "editor/getDiagnostics",
       params = { uri = "file:///nonexistent/file.lua" },
     }).diagnostics
   ]])
-  eq(#count, 0)
+  eq(#diagnostics, 0)
 end
 
 T["editor"]["maps severity levels correctly"] = function()
@@ -113,11 +113,11 @@ T["editor"]["uri field is present on each diagnostic"] = function()
   eq(child.lua_get("_G.uri_result[2]"), "file:///tmp/eca_test_uri.lua")
 end
 
-T["editor"]["returns empty table for unknown method"] = function()
-  local count = child.lua_get([[
-    vim.tbl_count(require("eca.editor").handle_request({ method = "editor/unknown", params = {} }))
+T["editor"]["returns nil for unknown method"] = function()
+  local is_nil = child.lua_get([[
+    require("eca.editor").handle_request({ method = "editor/unknown", params = {} }) == nil
   ]])
-  eq(count, 0)
+  eq(is_nil, true)
 end
 
 return T

--- a/tests/test_editor_diagnostics.lua
+++ b/tests/test_editor_diagnostics.lua
@@ -1,0 +1,123 @@
+local MiniTest = require("mini.test")
+local eq = MiniTest.expect.equality
+local child = MiniTest.new_child_neovim()
+
+local T = MiniTest.new_set({
+  hooks = {
+    pre_case = function()
+      child.restart({ "-u", "scripts/minimal_init.lua" })
+    end,
+    post_once = child.stop,
+  },
+})
+
+T["editor"] = MiniTest.new_set()
+
+T["editor"]["returns empty diagnostics when buffer not found"] = function()
+  local count = child.lua_get([[
+    require("eca.editor").handle_request({
+      method = "editor/getDiagnostics",
+      params = { uri = "file:///nonexistent/file.lua" },
+    }).diagnostics
+  ]])
+  eq(#count, 0)
+end
+
+T["editor"]["maps severity levels correctly"] = function()
+  child.lua([[
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, "/tmp/eca_test_sev.lua")
+    local ns = vim.api.nvim_create_namespace("eca_sev")
+    vim.diagnostic.set(ns, bufnr, {
+      { lnum=0, col=0, end_lnum=0, end_col=1, message="err",  severity=vim.diagnostic.severity.ERROR },
+      { lnum=1, col=0, end_lnum=1, end_col=1, message="warn", severity=vim.diagnostic.severity.WARN  },
+      { lnum=2, col=0, end_lnum=2, end_col=1, message="info", severity=vim.diagnostic.severity.INFO  },
+      { lnum=3, col=0, end_lnum=3, end_col=1, message="hint", severity=vim.diagnostic.severity.HINT  },
+    })
+    local res = require("eca.editor").handle_request({
+      method = "editor/getDiagnostics",
+      params = { uri = "file:///tmp/eca_test_sev.lua" },
+    })
+    _G.sev_result = {}
+    for _, d in ipairs(res.diagnostics) do
+      table.insert(_G.sev_result, d.severity)
+    end
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+  eq(child.lua_get("_G.sev_result[1]"), "error")
+  eq(child.lua_get("_G.sev_result[2]"), "warning")
+  eq(child.lua_get("_G.sev_result[3]"), "information")
+  eq(child.lua_get("_G.sev_result[4]"), "hint")
+end
+
+T["editor"]["includes range and message fields"] = function()
+  child.lua([[
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, "/tmp/eca_test_fields.lua")
+    local ns = vim.api.nvim_create_namespace("eca_fields")
+    vim.diagnostic.set(ns, bufnr, {
+      { lnum=5, col=3, end_lnum=5, end_col=10, message="test error", severity=vim.diagnostic.severity.ERROR, source="myls" },
+    })
+    local res = require("eca.editor").handle_request({
+      method = "editor/getDiagnostics",
+      params = { uri = "file:///tmp/eca_test_fields.lua" },
+    })
+    _G.field_result = res.diagnostics[1]
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+  eq(child.lua_get("_G.field_result.message"), "test error")
+  eq(child.lua_get("_G.field_result.range.start.line"), 5)
+  eq(child.lua_get("_G.field_result.range.start.character"), 3)
+  eq(child.lua_get([[_G.field_result.range["end"].line]]), 5)
+  eq(child.lua_get([[_G.field_result.range["end"].character]]), 10)
+end
+
+T["editor"]["falls back to information for unknown severity"] = function()
+  child.lua([[
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, "/tmp/eca_test_fallback.lua")
+    local ns = vim.api.nvim_create_namespace("eca_fallback")
+    vim.diagnostic.set(ns, bufnr, {
+      { lnum=0, col=0, end_lnum=0, end_col=1, message="x", severity=99 },
+    })
+    local res = require("eca.editor").handle_request({
+      method = "editor/getDiagnostics",
+      params = { uri = "file:///tmp/eca_test_fallback.lua" },
+    })
+    _G.fallback_sev = res.diagnostics[1] and res.diagnostics[1].severity
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+  eq(child.lua_get("_G.fallback_sev"), "information")
+end
+
+T["editor"]["uri field is present on each diagnostic"] = function()
+  child.lua([[
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, "/tmp/eca_test_uri.lua")
+    local ns = vim.api.nvim_create_namespace("eca_uri")
+    vim.diagnostic.set(ns, bufnr, {
+      { lnum=0, col=0, end_lnum=0, end_col=1, message="e1", severity=vim.diagnostic.severity.ERROR },
+      { lnum=1, col=0, end_lnum=1, end_col=1, message="e2", severity=vim.diagnostic.severity.WARN  },
+    })
+    local res = require("eca.editor").handle_request({
+      method = "editor/getDiagnostics",
+      params = { uri = "file:///tmp/eca_test_uri.lua" },
+    })
+    _G.uri_result = {}
+    for _, d in ipairs(res.diagnostics) do
+      table.insert(_G.uri_result, d.uri)
+    end
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  ]])
+  eq(child.lua_get("_G.uri_result[1]"), "file:///tmp/eca_test_uri.lua")
+  eq(child.lua_get("_G.uri_result[2]"), "file:///tmp/eca_test_uri.lua")
+end
+
+T["editor"]["returns empty table for unknown method"] = function()
+  local count = child.lua_get([[
+    vim.tbl_count(require("eca.editor").handle_request({ method = "editor/unknown", params = {} }))
+  ]])
+  eq(count, 0)
+end
+
+return T


### PR DESCRIPTION
## Summary

- Advertises `editor.diagnostics = true` capability in `initialize` handshake
- Handles server-initiated `editor/getDiagnostics` requests in `handle_message` (new `id + method` branch)
- New `editor.lua` module: maps vim diagnostics to protocol format, includes `uri` per diagnostic item (required by ECA server to format output)
- Adds `send_response()` for sending JSON-RPC responses back to server

Closes #26.

## Test plan

- [ ] All 6 unit tests in `tests/test_editor_diagnostics.lua` pass (`make test`)
- [ ] Open file with LSP diagnostics, ask ECA to check errors — confirm "Checking diagnostics ✅" with real output and no server-side error

🤖 Generated with [Claude Code](https://claude.com/claude-code)