### PR TITLE
fix: notify server when model is selected via EcaChatSelectModel

### DIFF
--- a/lua/eca/commands.lua
+++ b/lua/eca/commands.lua
@@ -454,7 +454,7 @@ function M.setup()
     }, function(choice)
       if choice then
         chat.mediator:update_selected_model(choice)
-        chat.mediator:send("chat/selectedModelChanged", { model = choice, variant = nil }, nil)
+        chat.mediator:send("chat/selectedModelChanged", { model = choice, variant = vim.NIL }, nil)
       end
     end)
   end, {

--- a/lua/eca/commands.lua
+++ b/lua/eca/commands.lua
@@ -454,6 +454,7 @@ function M.setup()
     }, function(choice)
       if choice then
         chat.mediator:update_selected_model(choice)
+        chat.mediator:send("chat/selectedModelChanged", { model = choice, variant = nil }, nil)
       end
     end)
   end, {

--- a/tests/test_select_commands.lua
+++ b/tests/test_select_commands.lua
@@ -82,6 +82,28 @@ T["EcaChatSelectModel"]["updates state when model selected"] = function()
   eq(child.lua_get("_G.State.config.models.selected"), "model2")
 end
 
+T["EcaChatSelectModel"]["notifies server of model change"] = function()
+  child.lua([[
+    _G.State.config.models.list = { "model1", "model2", "model3" }
+    _G.State.config.models.selected = "model1"
+
+    -- Capture outgoing notifications
+    _G.sent_notifications = {}
+    _G.Mediator.send = function(self, method, params, callback)
+      table.insert(_G.sent_notifications, { method = method, params = params })
+    end
+
+    _G.mock_select("model2")
+  ]])
+
+  child.cmd("EcaChatSelectModel")
+
+  local notifications = child.lua_get("_G.sent_notifications")
+  eq(#notifications, 1)
+  eq(notifications[1].method, "chat/selectedModelChanged")
+  eq(notifications[1].params.model, "model2")
+end
+
 T["EcaChatSelectModel"]["handles nil selection"] = function()
   -- Setup initial state
   child.lua([[


### PR DESCRIPTION
\`EcaChatSelectModel\` was updating local state only. The server was never notified of the model change, meaning variants weren't updated and \`last-config-notified\` fell out of sync.

Send \`chat/selectedModelChanged\` to the server on model selection, matching the approach used by eca-emacs. The local state update is kept for immediate header refresh, since the server's response to \`chat/selectedModelChanged\` does not include \`selectModel\`.

Note: \`/model\` in chat has a related server-side gap — \`chat-selected-model-changed\` does not include \`select-model\` in its \`notify-fields-changed-only!\` call, so \`last-config-notified\` falls out of sync when the picker is used first. This means a subsequent \`/model\` command may not update the client. That fix belongs in the eca server.