### PR TITLE
Only stop prompt on explicit stop command

### DIFF
--- a/lua/eca/commands.lua
+++ b/lua/eca/commands.lua
@@ -393,9 +393,15 @@ function M.setup()
 
   vim.api.nvim_create_user_command("EcaStopResponse", function()
     local eca = require("eca")
+    local chat = eca.get()
     local Utils = require("eca.utils")
 
     -- Force stop any ongoing streaming response
+    local chat_id = chat.mediator:id()
+    if chat_id then
+      chat.mediator:send("chat/promptStop", { chatId = chat_id }, nil)
+    end
+
     if eca.sidebar then
       eca.sidebar:_finalize_streaming_response()
       Logger.notify("Forced stop of streaming response", vim.log.levels.INFO)

--- a/lua/eca/sidebar.lua
+++ b/lua/eca/sidebar.lua
@@ -1721,11 +1721,6 @@ function M:_add_message(role, content)
 end
 function M:_finalize_streaming_response()
   if self._is_streaming then
-    local chat_id = self.mediator:id()
-    if chat_id then
-      self.mediator:send("chat/promptStop", { chatId = chat_id }, nil)
-    end
-
     Logger.debug("DEBUG: Finalizing streaming response")
     Logger.debug("DEBUG: Final buffer had " .. #(self._current_response_buffer or "") .. " chars")
 


### PR DESCRIPTION
Fixes “Prompt stopped” on toolCallPrepare and other unwanted events introduced in https://github.com/editor-code-assistant/eca-nvim/pull/63. This moves the “chat/promptStop” instruction inside the “EcaStopResponse” instead of the shared `_finalize_streaming_response` function.